### PR TITLE
Add SERVERADMIN_BASE_URL environment variable

### DIFF
--- a/adminapi/request.py
+++ b/adminapi/request.py
@@ -1,3 +1,4 @@
+import os
 import hashlib
 import hmac
 import time
@@ -16,7 +17,10 @@ try:
 except ImportError:
     import json
 
-BASE_URL = 'https://serveradmin.innogames.de/api'
+BASE_URL = os.environ.get(
+    'SERVERADMIN_BASE_URL',
+    'https://serveradmin.innogames.de/api'
+)
 
 
 def calc_security_token(auth_token, timestamp, content):


### PR DESCRIPTION
Allow to set environment variable to set the base url for serveradmin
api requests. This is usefull for test enviroments to point the url to a
testing system.