### PR TITLE
cli.py: Fix wrong output for integer fields

### DIFF
--- a/adminapi/cli.py
+++ b/adminapi/cli.py
@@ -107,7 +107,7 @@ def print_server(server, attribute_ids):
             continue
 
         value = server[attribute_id]
-        if value in [None, True, False]:
+        if any(value is v for v in (None, True, False)):
             value = '{{{}}}'.format(str(value).lower())
 
         values.append(value)


### PR DESCRIPTION
We have no information about the backend datatypes currently so integer
fields containing literally 1 or 0 match the fixed if clause and are
returned as boolean representation. This gives mixed output and is
wrong.

Current output:
        adminapi "project=xxx" -a world
                {0}
                {1}
                2

Expected output:
        adminapi "project=xxx" -a world
                0
                1
                2