### PR TITLE
Remove csrf requirement for index method

### DIFF
--- a/serveradmin/servershell/views.py
+++ b/serveradmin/servershell/views.py
@@ -39,7 +39,6 @@ NUM_SERVERS_DEFAULT = 100
 
 
 @login_required
-@ensure_csrf_cookie
 def index(request):
     attributes = Attribute.objects.all()
     attribute_groups = {}


### PR DESCRIPTION
This only does searches, so I don't see a reason why we have to verify
csrf. Also Firefox Custom Searches break due to this, which is a
quality of life problem.