### PR TITLE
Fix adminapi expecting object_id in various places

### DIFF
--- a/adminapi/dataset/__init__.py
+++ b/adminapi/dataset/__init__.py
@@ -106,6 +106,8 @@ class BaseQuery(object):
             attrs = attrs[0]
 
         self._restrict = {str(a) for a in attrs}
+        if 'object_id' not in attrs:
+            self._restrict.add('object_id')
 
         return self
 
@@ -226,6 +228,10 @@ class Query(BaseQuery):
             obj._confirm_changes()
 
     def _fetch_results(self):
+        # Query expects to always get object_id. If we don't ask for it,
+        # something has gone terribly wrong while preparing this Query.
+        assert self._restrict is None or 'object_id' in self._restrict
+
         request_data = {'filters': self._filters}
         if self._restrict is not None:
             request_data['restrict'] = self._restrict

--- a/adminapi/dataset/__init__.py
+++ b/adminapi/dataset/__init__.py
@@ -252,7 +252,7 @@ class DatasetObject(dict):
             if isinstance(value, (tuple, list, set, frozenset)):
                 attributes[attribute_id] = MultiAttr(value, self, attribute_id)
         super(DatasetObject, self).__init__(attributes)
-        self.object_id = self['object_id']
+        self.object_id = self.get('object_id')
         self._deleted = False
         self.old_values = {}
 


### PR DESCRIPTION
We no longer always return object_ids from the API if the client doesn't explicitly asks for it. This was done as our ruby/puppet implementation of the adminapi library does not expect receiving them if not asked for. Therefore we now have to make sure we ask for it explicitly in the Query class. Also the adminapi code used on the serverside of the API must not require object_id.