### PR TITLE
Avoid throwing non exception

### DIFF
--- a/serveradmin/resources/views.py
+++ b/serveradmin/resources/views.py
@@ -37,7 +37,7 @@ def index(request):
         current_collection = collection
         break
     else:
-        raise HttpResponseBadRequest('No matching current collection')
+        return HttpResponseBadRequest('No matching current collection')
 
     template_info = {
         'search_term': term,


### PR DESCRIPTION
HttpResponseBadRequest is not an exception, so it should not be thrown.
Otherwise it fails with:

```py-tb
File "serveradmin/serveradmin/resources/views.py", line 40, in index
  raise HttpResponseBadRequest('No matching current collection')
TypeError: exceptions must derive from BaseException
```