### PR TITLE
Make parmiko > 2.0 features optional 

### DIFF
--- a/adminapi/request.py
+++ b/adminapi/request.py
@@ -50,9 +50,15 @@ except ImportError:
     utc = FakeTimezone(name='UTC')
 
 from paramiko.agent import Agent
-from paramiko import RSAKey, ECDSAKey, Ed25519Key
 from paramiko.message import Message
 from paramiko.ssh_exception import SSHException, PasswordRequiredException
+try:
+    from paramiko import RSAKey, ECDSAKey, Ed25519Key
+    key_classes = (RSAKey, ECDSAKey, Ed25519Key)
+except ImportError:
+    # Ed25519Key requires paramiko >= 2.2
+    from paramiko import RSAKey, ECDSAKey
+    key_classes = (RSAKey, ECDSAKey)
 
 from adminapi.cmduser import get_auth_token
 from adminapi.filters import BaseFilter
@@ -65,10 +71,10 @@ def load_private_key_file(private_key_path):
     We support RSA, ECDSA and Ed25519 keys and return instances of:
     * paramiko.rsakey.RSAKey
     * paramiko.ecdsakey.ECDSAKey
-    * paramiko.ed25519key.Ed25519Key
+    * paramiko.ed25519key.Ed25519Key (requires paramiko >= 2.2)
     """
     # I don't think there is a key type independent way of doing this
-    for key_class in (RSAKey, ECDSAKey, Ed25519Key):
+    for key_class in key_classes:
         try:
             return key_class.from_private_key_file(private_key_path)
         except PasswordRequiredException as e:

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -36,11 +36,14 @@ application in serveradmin. You can then either add the private key to your
 ssh-agent or export the SERVERADMIN_KEY_PATH environment variable to the path
 of the private key::
 
-    # Use ssh-agent
-    ssh-add ~/.ssh/id_ed25519
+    # Use ssh-agent, passwords protected keys are supported
+    ssh-add ~/.ssh/id_rsa
 
-    # Use environment vairable
-    export SERVERADMIN_KEY_PATH=~/.ssh/id_ed25519
+    # Use environment vairable, passwords protected keys are _not_ supported
+    export SERVERADMIN_KEY_PATH=~/.ssh/id_rsa
+
+Note that for ed25519 key support both adminapi and serveradmin must have
+paramiko 2.2 or newer installed.
 
 To authenticate yourself via a pre shared key you need to set the
 SERVERADMIN_TOKEN environment variable or create a file called .adminapi in the


### PR DESCRIPTION
Stretch only ships python3-paramiko in version 2.0. This version lacks
support for ed25519 keys. Further yet this version is lacking the
PublicBlob helper class used to parse and sanitize public keys of
arbitrary types from their public key file format used by open ssh.

This patch makes serveradmin and adminapi degrade gracefully on older
paramiko versions.