### PR TITLE
Regenerate link after attr refresh

### DIFF
--- a/serveradmin/servershell/static/servershell/servershell.js
+++ b/serveradmin/servershell/static/servershell/servershell.js
@@ -43,7 +43,7 @@ function refresh_servers(callback) {
         }
 
         $('#shell_understood').text(data['understood']);
-        regenerate_link();
+
         return callback();
     });
 }
@@ -378,6 +378,8 @@ function render_server_table() {
     for (var i = 0; i < shown_attributes.length; i++) {
         $('#shell_attributes input[value="' + shown_attributes[i] + '"]').prop('checked', true);
     }
+    regenerate_link();
+
     build_server_table(search['servers'], shown_attributes, offset);
 }
 
@@ -1120,8 +1122,6 @@ $(function() {
         } else {
             render_server_table();
         }
-
-        regenerate_link();
     });
 
     $('#shell_attributes li').each(function() {


### PR DESCRIPTION
right now, if you add or remove an attribute from the server table using the command box, the perma/deeplink is not refreshed so the last change is not reflected in the link
this makes sure that the link is regenerated whenever the attribute list is updated