### PR TITLE
Allow the logo filename to be customized via settings.py

### DIFF
--- a/serveradmin/common/templatetags/common.py
+++ b/serveradmin/common/templatetags/common.py
@@ -13,10 +13,7 @@ register = template.Library()
 
 @register.simple_tag
 def logo():
-    if getattr(settings, 'IS_SECONDARY', False):
-        return settings.STATIC_URL + 'logo_innogames_bigbulb_120_warn.png'
-    else:
-        return settings.STATIC_URL + 'logo_innogames_bigbulb_120.png'
+    return settings.STATIC_URL + settings.LOGO_FILENAME
 
 
 @register.filter

--- a/serveradmin/settings.py
+++ b/serveradmin/settings.py
@@ -99,6 +99,10 @@ STATIC_ROOT = os.path.join(ROOT_DIR, '_static')
 # Example: "http://media.lawrence.com/static/"
 STATIC_URL = '/static/'
 
+# Filename for the logo image file
+# This file should reside in the STATIC_ROOT defined above
+LOGO_FILENAME = 'logo_innogames_bigbulb_120.png'
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
I'm facing a problem where everytime I upgrade serveradmin, my custom logo is gone. 

This PR allows the logo filename to be customized, in order to avoid this problem. 