### PR TITLE
task(api): Add user or application id to error

### DIFF
--- a/serveradmin/api/decorators.py
+++ b/serveradmin/api/decorators.py
@@ -134,10 +134,10 @@ def authenticate_app(
         raise SuspiciousOperation('Missing authentication')
 
     if app.owner is not None and not app.owner.is_active:
-        raise PermissionDenied('Inactive user')
+        raise PermissionDenied('Inactive user {}'.format(app.owner.id))
 
     if app.disabled:
-        raise PermissionDenied('Disabled application')
+        raise PermissionDenied('Disabled application {}'.format(app.id))
 
     # Note when this app was last used. We don't update this information more
     # than once every minute. Some apps authenticate thousand of times per


### PR DESCRIPTION
Add user and application id to PermissionDenied error to be able to see which user/application was disabled in error log. As the error message is also send to the client as response we only use the user/application id to not expose sensitive information.