### PR TITLE
fix(servershell): Use ServertypeAttribute default visible

### DIFF
--- a/serveradmin/servershell/helper/__init__.py
+++ b/serveradmin/servershell/helper/__init__.py
@@ -1,4 +1,4 @@
-from serveradmin.serverdb.models import Attribute
+from serveradmin.serverdb.models import Attribute, ServertypeAttribute
 
 
 def get_default_shown_attributes():
@@ -9,7 +9,8 @@ def get_default_shown_attributes():
 
     shown_attributes = list(Attribute.specials.keys())
     shown_attributes.remove('object_id')
-    shown_attributes.append('state')
-    shown_attributes.sort()
+    default_attributes = ServertypeAttribute.objects.filter(
+        default_visible=True).only('attribute_id').distinct()
+    shown_attributes.extend([attr.attribute_id for attr in default_attributes])
 
     return shown_attributes


### PR DESCRIPTION
The state attribute is InnoGames internal and we have a default visible
attribute for each Servertype we can use to generate a default list of
attributes visible in Servershell.