### PR TITLE
task: Update distribute and python versions for tests

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.5
+  version: 3.7
   # Remove this once rtd merged Pipfile support:
   # https://github.com/readthedocs/readthedocs.org/pull/4783
   install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 sudo: false
 services:
     - postgresql
@@ -6,10 +6,12 @@ addons:
     postgresql: "9.6"
 language: python
 python:
-    - "3.4"
-    - "3.5"
+    - "3.5" # Required for Debian Stretch support
     - "3.6"
+    - "3.7"
+    # - "3.8" Django 1.10 does not support 3.8 we need to upgrade it first
 install:
+    - pip install --upgrade pip
     - pip install pipenv
     - pipenv lock
     - pipenv install --dev


### PR DESCRIPTION
- Use Ubuntu Bionic 18.04 LTS for running tests
- Test all needed Python versions 3.5 (Debian Stretch) to 3.7 (Debian Buster)

This drops support for Python 3.4. Support for Python 3.8 is not yet in tests break for Django 1.10 we have to upgrade Django first.