### PR TITLE
Add unit tests for command line interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
     - python -m serveradmin migrate
 script:
     # This will use Python's standard unit test discovery feature.
-    - python -Wall -m serveradmin test
+    - python -Wall -m serveradmin test --noinput
     # Build sphinx docs, error on warning
     - cd docs
     - SPHINXOPTS='-W' make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
     - python -m serveradmin migrate
 script:
     # This will use Python's standard unit test discovery feature.
-    - python -Wall -m serveradmin test --noinput
+    - python -Wall -m serveradmin test --noinput --parallel
     # Build sphinx docs, error on warning
     - cd docs
     - SPHINXOPTS='-W' make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_script:
     - python -m serveradmin migrate
 script:
     # This will use Python's standard unit test discovery feature.
+    - python -m unittest discover adminapi -v
     - python -Wall -m serveradmin test --noinput --parallel
     # Build sphinx docs, error on warning
     - cd docs

--- a/adminapi/cli.py
+++ b/adminapi/cli.py
@@ -2,14 +2,14 @@
 
 Copyright (c) 2019 InnoGames GmbH
 """
-
+import sys
 from argparse import ArgumentParser, ArgumentTypeError
 
 from adminapi.dataset import Query
 from adminapi.parse import parse_query
 
 
-def parse_args():
+def parse_args(args):
     multi_note = ' (can be specified multiple times)'
     parser = ArgumentParser('adminapi')
     parser.add_argument('query', nargs='+')
@@ -45,11 +45,11 @@ def parse_args():
         help='Attributes with values to update' + multi_note,
     )
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def main():
-    args = parse_args()
+    args = parse_args(sys.argv[1:])
 
     attribute_ids_to_print = args.attr if args.attr else ['hostname']
     attribute_ids_to_fetch = list(attribute_ids_to_print)

--- a/adminapi/tests/test_cli.py
+++ b/adminapi/tests/test_cli.py
@@ -1,0 +1,68 @@
+import unittest
+from argparse import ArgumentParser
+from typing import Text, NoReturn
+
+from adminapi.cli import parse_args
+
+
+# ArgumentParser exists on error, we cannot capture this so we override it
+class ArgumentParserMock(ArgumentParser):
+    def error(self, message: Text) -> NoReturn:
+        raise Exception(message)
+
+
+class TestCommandlineInterface(unittest.TestCase):
+    def test_no_argument(self, *args):
+        with self.assertRaises(SystemExit) as e:
+            parse_args([])
+
+    def test_unknown_argument(self, *args):
+        with self.assertRaises(SystemExit) as e:
+            parse_args(['project=adminapi', '--attr', 'state', 'spaceship'])
+
+    def test_one_argument(self, *args):
+        args = parse_args(['project=adminapi', '--one'])
+        self.assertTrue(args.one)
+
+        args = parse_args(['project=adminapi', '-1'])
+        self.assertTrue(args.one)
+
+    def test_attr_argument(self, *args):
+        args = parse_args(['project=adminapi', '--attr', 'hostname'])
+        self.assertEqual(args.attr, ['hostname'])
+
+        args = parse_args(['project=adminapi', '-a', 'hostname'])
+        self.assertEqual(args.attr, ['hostname'])
+
+        args = parse_args(['project=adminapi', '--attr', 'hostname', '-a', 'state'])
+        self.assertEqual(args.attr, ['hostname', 'state'])
+
+    def test_order_argument(self, *args):
+        args = parse_args(['project=adminapi', '--order', 'hostname'])
+        self.assertEqual(args.order, ['hostname'])
+
+        args = parse_args(['project=adminapi', '-o', 'hostname'])
+        self.assertEqual(args.order, ['hostname'])
+
+        args = parse_args(['project=adminapi', '--order', 'hostname', '-o', 'state'])
+        self.assertEqual(args.order, ['hostname', 'state'])
+
+    def test_reset_argument(self, *args):
+        args = parse_args(['project=adminapi', '--reset', 'responsible_admins'])
+        self.assertEqual(args.reset, ['responsible_admins'])
+
+        args = parse_args(['project=adminapi', '-r', 'responsible_admins'])
+        self.assertEqual(args.reset, ['responsible_admins'])
+
+        args = parse_args(['project=adminapi', '--reset', 'responsible_admins', '-r', 'service_groups'])
+        self.assertEqual(args.reset, ['responsible_admins', 'service_groups'])
+
+    def test_update_argument(self, *args):
+        args = parse_args(['project=adminapi', '--update', 'hostname=SomeNewHostname'])
+        self.assertEqual(args.update, [('hostname', 'SomeNewHostname')])
+
+        args = parse_args(['project=adminapi', '-u', 'hostname=SomeNewHostname'])
+        self.assertEqual(args.update, [('hostname', 'SomeNewHostname')])
+
+        args = parse_args(['project=adminapi', '--update', 'hostname=SomeNewHostname', '-u', 'state=maintenance'])
+        self.assertEqual(args.update, [('hostname', 'SomeNewHostname'), ('state', 'maintenance')])


### PR DESCRIPTION
Add unit tests for the argument parser of the command line interface to guarantee a stable interface not breaking clients or users behavior on changes.