### PR TITLE
feature: Provide server side DatasetObject

### DIFF
--- a/serveradmin/dataset.py
+++ b/serveradmin/dataset.py
@@ -3,7 +3,7 @@
 Copyright (c) 2019 InnoGames GmbH
 """
 
-from adminapi.dataset import BaseQuery, DatasetObject
+from adminapi.dataset import BaseQuery, DatasetObject as ApiDatasetObject
 from serveradmin.serverdb.query_committer import commit_query
 from serveradmin.serverdb.query_executer import execute_query
 from serveradmin.serverdb.query_materializer import (
@@ -23,3 +23,10 @@ class Query(BaseQuery):
 
     def _fetch_results(self):
         return execute_query(self._filters, self._restrict, self._order_by)
+
+
+class DatasetObject(ApiDatasetObject):
+    def commit(self, app=None, user=None):
+        commit_obj = self._build_commit_object()
+        commit_query(app=app, user=user, **commit_obj)
+        self._confirm_changes()


### PR DESCRIPTION
We provide already a server side Query implementation which allows executing
Serveradmin queries without doing an actual HTTP request including all
the overhead of authorisation and authentication by just passing the
user or application directly.

This makes also the DatasetObject and its commit method available as
server side implementation.

This can be useful for many things but the intention here is to be able to
write proper unit tests and being able to commit data in a isolated test
database using the Django TransactionTestCase class.