### PR TITLE
fix(common): Zero columns make range function fail

### DIFF
--- a/serveradmin/common/templatetags/common.py
+++ b/serveradmin/common/templatetags/common.py
@@ -47,6 +47,11 @@ def group(items, number_of_groups):
 
     groups = list()
     step = round(len(items) / number_of_groups)
+
+    # When the amount of columns is zero show at least one
+    if step == 0:
+        step = 1
+
     for counter in range(0, len(items), step):
         groups.extend([items[counter:counter + step]])
 


### PR DESCRIPTION
When passing few items with a big grouper to the group templatetag the
step counter can be zero which breaks the range function. It must be at
least one to show one column and not break the range function.