### PR TITLE
fix(adminapi): No retry at timeout or abortion

### DIFF
--- a/adminapi/request.py
+++ b/adminapi/request.py
@@ -6,6 +6,8 @@ Copyright (c) 2019 InnoGames GmbH
 import os
 from hashlib import sha1
 import hmac
+from http.client import IncompleteRead
+from socket import timeout
 from ssl import SSLError
 import time
 import json
@@ -200,7 +202,7 @@ def _try_request(request, retry=False):
                 message = payload['error']['message']
             raise ApiError(message, status_code=error.code)
         raise
-    except (SSLError, URLError):
+    except (SSLError, URLError, timeout, IncompleteRead):
         if retry:
             return None
         raise


### PR DESCRIPTION
We also want to apply the retry logic for a request when a connection
can not be established and fails with a timeout error raised from the
socket module and when a already established connection gets aborted or
fails with an IncompleteRead exception caused by e.g. routing issues.