### PR TITLE
fix: Move VERSION from serveradmin to adminapi

### DIFF
--- a/adminapi/__init__.py
+++ b/adminapi/__init__.py
@@ -1,17 +1,4 @@
 """Serveradmin - adminapi
 
-Copyright (c) 2018 InnoGames GmbH
+Copyright (c) 2020 InnoGames GmbH
 """
-
-from adminapi.request import Settings
-
-
-# XXX Deprecated
-def auth(auth_token=None):
-    if auth_token:
-        Settings.auth_token = auth_token
-
-
-# XXX Deprecated
-def set_timeout(timeout, what='api'):
-    Settings.timeout = timeout

--- a/adminapi/__init__.py
+++ b/adminapi/__init__.py
@@ -2,3 +2,5 @@
 
 Copyright (c) 2020 InnoGames GmbH
 """
+
+VERSION = (1, 9, 3)

--- a/adminapi/request.py
+++ b/adminapi/request.py
@@ -22,7 +22,7 @@ from paramiko.agent import Agent
 from paramiko.message import Message
 from paramiko.ssh_exception import SSHException, PasswordRequiredException
 
-from serveradmin import VERSION
+from adminapi import VERSION
 
 try:
     from paramiko import RSAKey, ECDSAKey, Ed25519Key

--- a/serveradmin/__init__.py
+++ b/serveradmin/__init__.py
@@ -2,5 +2,3 @@
 
 Copyright (c) 2020 InnoGames GmbH
 """
-
-VERSION = (1, 9, 3)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ Copyright (c) 2019 InnoGames GmbH
 """
 
 from setuptools import setup, find_packages
-from serveradmin import VERSION as SERVERADMIN_VERSION
+from adminapi import VERSION as SERVERADMIN_VERSION
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Running serveradmin without adminapi module is impossible right now due
to code dependencies. Running adminapi without serveradmin however
should be possible but became impossible by sending the version as
header.