### PR TITLE
Fix URL to render graphite graphs

### DIFF
--- a/serveradmin/graphite/templates/graphite/graph_table.html
+++ b/serveradmin/graphite/templates/graphite/graph_table.html
@@ -87,7 +87,7 @@
             <tr>
                 {% for column_name, graph in graph_column %}
                 <td>
-                    <img class="graph" src="{% url 'graphite_graph' %}/render?{{ graph }}"  alt="{{ name }} {{ column_name }}" />
+                    <img class="graph" src="{% url 'graphite_graph' %}?{{ graph }}"  alt="{{ name }} {{ column_name }}" />
                 </td>
                 {% endfor %}
             </tr>


### PR DESCRIPTION
The old URL syntax (=< Django 1.11) also matched starting routes such as /graph/render but now requires and exact match to /graph.