### PR TITLE
Fix supernet attribute breaks optional intern_ip

### DIFF
--- a/serveradmin/serverdb/admin.py
+++ b/serveradmin/serverdb/admin.py
@@ -5,6 +5,10 @@ Copyright (c) 2019 InnoGames GmbH
 
 from django.contrib import admin
 
+from serveradmin.serverdb.forms import (
+    ServertypeAttributeAdminForm,
+    ServertypeAdminForm,
+)
 from serveradmin.serverdb.models import (
     Servertype,
     Attribute,
@@ -17,10 +21,12 @@ from serveradmin.serverdb.models import (
 
 
 class ServertypeAttributeInline(admin.TabularInline):
+    form = ServertypeAttributeAdminForm
     model = ServertypeAttribute
 
 
 class ServertypeAdmin(admin.ModelAdmin):
+    form = ServertypeAdminForm
     inlines = (
         ServertypeAttributeInline,
     )

--- a/serveradmin/serverdb/forms.py
+++ b/serveradmin/serverdb/forms.py
@@ -1,0 +1,43 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+
+
+class ServertypeAdminForm(forms.ModelForm):
+    def clean(self):
+        if self.cleaned_data.get('ip_addr_type') == 'null':
+            supernet_and_required = self.instance.attributes.filter(
+                required=True,
+                attribute__type='supernet'
+            ).only('attriute_id').values_list('attribute_id', flat=True)
+            if supernet_and_required.exists():
+                raise ValidationError(_(
+                        'ip_addr_type for Servertype must not be "null" '
+                        'if any attribute of type supernet is required '
+                        'but %(attrs)s is/are!'
+                    ),
+                    code='invalid',
+                    params={
+                        'attrs': ','.join(supernet_and_required)
+                    })
+        super().clean()
+
+
+class ServertypeAttributeAdminForm(forms.ModelForm):
+    def clean(self):
+        supernet_and_required = (
+            self.instance.attribute.type == 'supernet' and
+            self.instance.servertype.ip_addr_type == 'null' and
+            self.cleaned_data.get('required') is True
+        )
+        if supernet_and_required:
+            raise ValidationError(_(
+                    'Attributes of type %(type)s can not be required if '
+                    'ip_addr_type of Servertype is null!'
+                ),
+                code='invalid',
+                params={
+                    'attribute': self.instance.attribute.attribute_id,
+                    'type': self.instance.attribute.type,
+                })
+        super().clean()

--- a/serveradmin/serverdb/query_materializer.py
+++ b/serveradmin/serverdb/query_materializer.py
@@ -191,7 +191,7 @@ class QueryMaterializer:
                 elif source.intern_ip not in network:
                     continue
             # Check for a new target
-            if target is None:
+            if target is None and source.intern_ip:
                 try:
                     target = source.get_supernet(attribute.target_servertype)
                 except Server.DoesNotExist:


### PR DESCRIPTION
- Fix supernet attribute requires intern_ip
- Deny to make supernet attribute mandatory if intern_ip is optional (Admin)
- Deny to make intern_ip optional if any supernet attribute is mandatory (Admin)