### PR TITLE
Fix server errors (HTTP 500) due to duplicate intern_ip attribute values

### DIFF
--- a/serveradmin/serverdb/query_committer.py
+++ b/serveradmin/serverdb/query_committer.py
@@ -698,7 +698,7 @@ def _insert_server(hostname, intern_ip, servertype, attributes):
     if Server.objects.filter(hostname=hostname).exists():
         raise CommitError('Server with that hostname already exists')
 
-    server = Server.objects.create(
+    server = Server(
         hostname=hostname,
         intern_ip=intern_ip,
         servertype=servertype,


### PR DESCRIPTION
When cloning an object with the Servershell do not clone the intern_ip.
It must always be uniq and will conflict on save we are better of by
forcing the user to choose a IP address in the first place.