### PR TITLE
WIP: Fix submitting datetime in Servershell causes Server Error

### DIFF
--- a/adminapi/dataset.py
+++ b/adminapi/dataset.py
@@ -9,7 +9,7 @@ from itertools import chain
 from types import GeneratorType
 
 from adminapi import api
-from adminapi.datatype import validate_value, json_to_datatype
+from adminapi.datatype import validate_value, json_to_datatype, str_to_datatype
 from adminapi.filters import Any, BaseFilter, ContainedOnlyBy
 from adminapi.request import send_request, json_encode_extra
 from adminapi.exceptions import DatasetError, AdminapiException
@@ -417,6 +417,14 @@ class DatasetObject(dict):
                 self.old_values[key] = old_value
 
     def __setitem__(self, key, value):
+        if type(value) is str:
+            # We don't know the data type of the attribute here.
+            #
+            # If the attribute value is a string we try to match it against
+            # our known data types (True = 1, 0, true, false) etc. and convert
+            # it. If nothing matches we assume it is a string.
+            value = str_to_datatype(value)
+
         if isinstance(self[key], MultiAttr):
             value = MultiAttr(value, self, key)
         elif isinstance(value, GeneratorType):

--- a/serveradmin/servershell/templates/servershell/edit.html
+++ b/serveradmin/servershell/templates/servershell/edit.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load servershell %}
+
 {% block title %}
     Edit {% if object_id %}{{ object_id }}{% else %}New Object{% endif %}
 {% endblock %}
@@ -43,25 +45,19 @@
                         </td>
                         <td>
                             {% if field.multi %}
-                                <textarea class="edit_value"
-                                        rows="3"
-                                        cols="70"
-                                        name="attr_{{ field.key }}"
+                                <textarea class="edit_value" rows="3"  cols="70"  name="attr_{{ field.key }}"
                                         {% if field.readonly %} disabled="disabled"{% endif %}
                                         {% if field.required %} required {% endif %}
                                         {% if field.regexp %}data-pattern="{{ field.regexp }}"{% endif %}
-                                >{% for value in field.value %}{{ value}}
-{% endfor %}</textarea>
+                                >{% if field.value != None %}{{ field|field_to_str }}{% endif %}</textarea>
                             {% else %}
-                        <input class="edit_value"
-                               type="text"
-                               name="attr_{{ field.key }}"
-                               value="{% if field.type == 'boolean' %}{{ field.value|lower }}{% elif field.value != None %}{{ field.value }}{% endif %}"
-                               size="70"
-                               {% if field.readonly %}disabled="disabled" {% endif %}
-                               {% if field.regexp %}data-pattern="{{ field.regexp }}"{% endif %}
-                               {% if field.required %} required {% endif %}
-                               {% if field.key == 'intern_ip' %}readonly onclick="servershell.choose_ip_address();"{% endif %}/>
+                                <input class="edit_value"  type="text"  name="attr_{{ field.key }}"
+                                       value="{% if field.value != None %}{{ field|field_to_str }}{% endif %}"
+                                       size="70" {% if field.readonly %}disabled="disabled" {% endif %}
+                                       {% if field.regexp %}data-pattern="{{ field.regexp }}"{% endif %}
+                                       {% if field.required %} required {% endif %}
+                                       {% if field.key == 'intern_ip' %}readonly onclick="servershell.choose_ip_address();"{% endif %}
+                                />
                             {% endif %}
                         </td>
                         <td>

--- a/serveradmin/servershell/templates/servershell/inspect.html
+++ b/serveradmin/servershell/templates/servershell/inspect.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load servershell %}
+
 {% block title %}
     Inspect {{ object_id }}
 {% endblock %}
@@ -32,14 +34,14 @@
                 <tr>
                     <td>{{ field.key }}</td>
                     <td>
-                        {% if field.multi %}
+                        {% if field.multi and field.value != None %}
                             <ul>
                                 {% for val in field.value %}
-                                    <li>{{ val }}</li>
+                                    <li>{{ val|value_to_str:field.type }}</li>
                                 {% endfor %}
                             </ul>
                         {% else %}
-                            {{ field.value }}
+                            {% if field.value != None %}{{ field.value|value_to_str:field.type }}{% endif %}
                         {% endif %}
                     </td>
                     <td>{{ field.type }}</td>

--- a/serveradmin/servershell/templatetags/servershell.py
+++ b/serveradmin/servershell/templatetags/servershell.py
@@ -1,0 +1,49 @@
+from datetime import timezone
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def field_to_str(field: dict) -> str:
+    """Get field value string representation
+
+    We have a custom string representation for some types that should be
+    uniform in all views edit, inspect, servershell as well as in the command
+    line interface.
+
+    :param field:
+    :return:
+    """
+
+    if field['multi']:
+        values = list()
+        for value in field['value']:
+            values.append(value_to_str(value, field['type']))
+
+        return '\n'.join(values)
+
+    return value_to_str(field['value'], field['type'])
+
+
+@register.filter
+def value_to_str(value, field_type) -> str:
+    """Get value string representation
+
+    Similar to field_to_str but returns the string representation directly
+    for a value.
+
+    :param value:
+    :param field_type:
+    :return:
+    """
+
+    if field_type == 'datetime':
+        if value.tzinfo is None:
+            value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S%z')
+    elif field_type == 'boolean':
+        return str(value).lower()
+
+    return str(value)

--- a/serveradmin/servershell/templatetags/servershell.py
+++ b/serveradmin/servershell/templatetags/servershell.py
@@ -39,11 +39,21 @@ def value_to_str(value, field_type) -> str:
     :return:
     """
 
-    if field_type == 'datetime':
+    # somewhere, in general more global, could be for now also just inside this function
+    def conversion_datetime(value):
         if value.tzinfo is None:
             value.replace(tzinfo=timezone.utc)
         return value.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S%z')
-    elif field_type == 'boolean':
-        return str(value).lower()
+        
+    conversions = {
+        'datetime': conversion_datetime,
+        'boolean': lambda v: str(v).lower()
+    }
+
+    conv = conversions.get(field_type)
+    if conv is None:
+        return str(value)
+        
+    return conv(value)
 
     return str(value)


### PR DESCRIPTION
- Use same string representation in UI to avoid confusion
- Convert string values to desired data type (e.g. datetime)
- Fix submitting datetime in Servershell causes server error