### PR TITLE
Use consistent string representation in views

### DIFF
--- a/serveradmin/servershell/templates/servershell/edit.html
+++ b/serveradmin/servershell/templates/servershell/edit.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load servershell %}
+
 {% block title %}
     Edit {% if object_id %}{{ object_id }}{% else %}New Object{% endif %}
 {% endblock %}
@@ -43,25 +45,19 @@
                         </td>
                         <td>
                             {% if field.multi %}
-                                <textarea class="edit_value"
-                                        rows="3"
-                                        cols="70"
-                                        name="attr_{{ field.key }}"
+                                <textarea class="edit_value" rows="3"  cols="70"  name="attr_{{ field.key }}"
                                         {% if field.readonly %} disabled="disabled"{% endif %}
                                         {% if field.required %} required {% endif %}
                                         {% if field.regexp %}data-pattern="{{ field.regexp }}"{% endif %}
-                                >{% for value in field.value %}{{ value}}
-{% endfor %}</textarea>
+                                >{% if field.value != None %}{{ field|field_to_str }}{% endif %}</textarea>
                             {% else %}
-                        <input class="edit_value"
-                               type="text"
-                               name="attr_{{ field.key }}"
-                               value="{% if field.type == 'boolean' %}{{ field.value|lower }}{% elif field.value != None %}{{ field.value }}{% endif %}"
-                               size="70"
-                               {% if field.readonly %}disabled="disabled" {% endif %}
-                               {% if field.regexp %}data-pattern="{{ field.regexp }}"{% endif %}
-                               {% if field.required %} required {% endif %}
-                               {% if field.key == 'intern_ip' %}readonly onclick="servershell.choose_ip_address();"{% endif %}/>
+                                <input class="edit_value"  type="text"  name="attr_{{ field.key }}"
+                                       value="{% if field.value != None %}{{ field|field_to_str }}{% endif %}"
+                                       size="70" {% if field.readonly %}disabled="disabled" {% endif %}
+                                       {% if field.regexp %}data-pattern="{{ field.regexp }}"{% endif %}
+                                       {% if field.required %} required {% endif %}
+                                       {% if field.key == 'intern_ip' %}readonly onclick="servershell.choose_ip_address();"{% endif %}
+                                />
                             {% endif %}
                         </td>
                         <td>

--- a/serveradmin/servershell/templates/servershell/inspect.html
+++ b/serveradmin/servershell/templates/servershell/inspect.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load servershell %}
+
 {% block title %}
     Inspect {{ object_id }}
 {% endblock %}
@@ -32,14 +34,14 @@
                 <tr>
                     <td>{{ field.key }}</td>
                     <td>
-                        {% if field.multi %}
+                        {% if field.multi and field.value != None %}
                             <ul>
                                 {% for val in field.value %}
-                                    <li>{{ val }}</li>
+                                    <li>{{ val|value_to_str:field.type }}</li>
                                 {% endfor %}
                             </ul>
                         {% else %}
-                            {{ field.value }}
+                            {% if field.value != None %}{{ field.value|value_to_str:field.type }}{% endif %}
                         {% endif %}
                     </td>
                     <td>{{ field.type }}</td>

--- a/serveradmin/servershell/templatetags/servershell.py
+++ b/serveradmin/servershell/templatetags/servershell.py
@@ -1,0 +1,57 @@
+from datetime import timezone
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def field_to_str(field: dict) -> str:
+    """Get field value string representation
+
+    We have a custom string representation for some types that should be
+    uniform in all views edit, inspect, servershell as well as in the command
+    line interface.
+
+    :param field:
+    :return:
+    """
+
+    if field['multi']:
+        values = list()
+        for value in field['value']:
+            values.append(value_to_str(value, field['type']))
+
+        return '\n'.join(values)
+
+    return value_to_str(field['value'], field['type'])
+
+
+@register.filter
+def value_to_str(value, field_type) -> str:
+    """Get value string representation
+
+    Similar to field_to_str but returns the string representation directly
+    for a value.
+
+    :param value:
+    :param field_type:
+    :return:
+    """
+
+    # @TODO Maybe we can use ServerAttribute models and __str__ method here
+    def conversion_datetime(value):
+        if value.tzinfo is None:
+            value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S%z')
+
+    conversions = {
+        'datetime': conversion_datetime,
+        'boolean': lambda v: str(v).lower(),
+    }
+
+    conv = conversions.get(field_type)
+    if conv is None:
+        return str(value)
+
+    return conv(value)

--- a/serveradmin/servershell/views.py
+++ b/serveradmin/servershell/views.py
@@ -215,6 +215,7 @@ def edit(request):
 
 
 def _edit(request, server, edit_mode=False, template='edit'):  # NOQA: C901
+    # @TODO work with ServerAttribute models here and use Django forms
     invalid_attrs = set()
     if edit_mode and request.POST:
         attribute_lookup = {a.pk: a for a in Attribute.objects.filter(


### PR DESCRIPTION
We want a consistent string representation of attribute value in all
views in Serveradmin. Using different representations for e.g. datetime
is confusing for users.