### PR TITLE
Show app and owner in Servershell history

### DIFF
--- a/serveradmin/serverdb/templates/serverdb/history.html
+++ b/serveradmin/serverdb/templates/serverdb/history.html
@@ -36,7 +36,8 @@
                 <tr>
                     <th>Date</th>
                     <th>Time Since</th>
-                    <th>Author</th>
+                    <th>App</th>
+                    <th>Owner</th>
                     <th>Attribute</th>
                     <th>New/Added</th>
                     <th>Old/Removed</th>
@@ -49,6 +50,7 @@
                             <tr>
                                 <td>{{ change.commit.change_on|date:"r" }}</td>
                                 <td>{{ change.commit.change_on|timesince }}</td>
+                                <td>{{ change.commit.app|default:"Servershell" }}</td>
                                 <td>{{ change.commit.user }}</td>
                                 <td>{{ key }}:</td>
                                 <td>
@@ -71,6 +73,7 @@
                                 <tr>
                                     <td>{{ change.commit.change_on|date:"r" }}</td>
                                     <td>{{ change.commit.change_on|timesince }}</td>
+                                    <td>{{ change.commit.app|default:"Servershell" }}</td>
                                     <td>{{ change.commit.user }}</td>
                                     <td>{{ key }}</td>
                                     {% if value.action == 'multi' %}


### PR DESCRIPTION
One often wants to know which app (token) has made changes additionally
to the owner of the app since one owner may have multiple apps.