### PR TITLE
Do not crash if the key is in wrong format

### DIFF
--- a/adminapi/request.py
+++ b/adminapi/request.py
@@ -75,6 +75,16 @@ def calc_message(timestamp, data=None):
     return str(timestamp) + (':' + data) if data else str(timestamp)
 
 
+def signable(key):
+    """Checks if key is able to sign the message
+    """
+    try:
+        key.sign_ssh_data(b'')
+        return True
+    except SSHException:
+        return False
+
+
 def calc_signature(private_key, timestamp, data=None):
     """Create a proof that we posess the private key
 
@@ -158,7 +168,7 @@ def _build_request(endpoint, get_params, post_params):
     else:
         try:
             agent = Agent()
-            agent_keys = agent.get_keys()
+            agent_keys = filter(signable, agent.get_keys())
         except SSHException:
             raise AuthenticationError('No token and ssh agent found')
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ if __name__ == '__main__':
                 'adminapi=adminapi.__main__:main',
             ],
         },
+        install_require=[
+            'paramiko',
+            'netaddr',
+        ],
         author='InnoGames System Administration',
         author_email='it@innogames.com',
     )


### PR DESCRIPTION
With yubikey PIV two keys are provided:

```
> ssh-add -l
256 SHA256:ZohTkUG5ko5xzL0/ZcLX5t8m8ybEiXoCOdLeKVERxsE Public key for PIV Authentication (ECDSA)
2048 SHA256:a2L69IagYYYfJ1PDYhrj0GLT0i3EZa3mleARfdMaTZc Public key for PIV Attestation (RSA)
```

And the first one is unable to sign the message for some reason. But it's not the reason to crush.