### PR TITLE
Several quick performance improvements

### DIFF
--- a/serveradmin/serverdb/models.py
+++ b/serveradmin/serverdb/models.py
@@ -463,7 +463,7 @@ class ServerStringAttribute(ServerAttribute):
 class ServerRelationAttributeManager(models.Manager):
     def get_queryset(self):
         manager = super(ServerRelationAttributeManager, self)
-        return manager.get_queryset().select_related('value')
+        return manager.get_queryset().prefetch_related('value')
 
 
 class ServerRelationAttribute(ServerAttribute):

--- a/serveradmin/serverdb/query_executer.py
+++ b/serveradmin/serverdb/query_executer.py
@@ -258,6 +258,6 @@ def _get_servers(filters, attribute_lookup, related_vias):
     # easy: get and execute the raw SQL query.
     sql_query = get_server_query(attribute_filters, related_vias)
     try:
-        return list(Server.objects.raw(sql_query))
+        return list(Server.objects.defer('intern_ip').raw(sql_query))
     except DataError as error:
         raise ValidationError(error)

--- a/serveradmin/serverdb/query_materializer.py
+++ b/serveradmin/serverdb/query_materializer.py
@@ -136,7 +136,10 @@ class QueryMaterializer:
                 for sa in ServerRelationAttribute.objects.filter(
                     value_id__in=self._server_attributes.keys(),
                     attribute_id__in=reversed_attributes.keys(),
-                ).select_related('server'):
+                ).select_related('server').defer(
+                    'server__intern_ip',
+                    'server__servertype',
+                ):
                     self._add_attribute_value(
                         sa.value,
                         reversed_attributes[sa.attribute_id],
@@ -147,7 +150,10 @@ class QueryMaterializer:
                 for sa in ServerAttribute.get_model(key).objects.filter(
                     server__in=self._server_attributes.keys(),
                     attribute__in=attributes,
-                ).select_related('server'):
+                ).select_related('server').defer(
+                    'server__intern_ip',
+                    'server__servertype',
+                ):
                     self._add_attribute_value(
                         sa.server,
                         attribute_lookup[sa.attribute_id],
@@ -221,7 +227,10 @@ class QueryMaterializer:
         for sa in ServerAttribute.get_model(attribute.type).objects.filter(
             server__hostname__in=servers_by_related.keys(),
             attribute=attribute,
-        ).select_related('server'):
+        ).select_related('server').defer(
+            'server__intern_ip',
+            'server__servertype',
+        ):
             for target in servers_by_related[sa.server]:
                 self._add_attribute_value(target, attribute, sa.get_value())
 

--- a/serveradmin/serverdb/query_materializer.py
+++ b/serveradmin/serverdb/query_materializer.py
@@ -100,7 +100,7 @@ class QueryMaterializer:
             sa = ServertypeAttribute.objects.filter(
                 servertype_id=sa.servertype_id,
                 attribute_id=related_via_attribute_id,
-            ).select_related('attribute').get()
+            ).prefetch_related('attribute').get()
             self._select_servertype_attribute(sa.attribute, sa)
 
     def _initialize_attributes(self, servers_by_type):
@@ -136,7 +136,7 @@ class QueryMaterializer:
                 for sa in ServerRelationAttribute.objects.filter(
                     value_id__in=self._server_attributes.keys(),
                     attribute_id__in=reversed_attributes.keys(),
-                ).select_related('server').defer(
+                ).prefetch_related('server').defer(
                     'server__intern_ip',
                     'server__servertype',
                 ):
@@ -150,7 +150,7 @@ class QueryMaterializer:
                 for sa in ServerAttribute.get_model(key).objects.filter(
                     server__in=self._server_attributes.keys(),
                     attribute__in=attributes,
-                ).select_related('server').defer(
+                ).prefetch_related('server').defer(
                     'server__intern_ip',
                     'server__servertype',
                 ):
@@ -227,7 +227,7 @@ class QueryMaterializer:
         for sa in ServerAttribute.get_model(attribute.type).objects.filter(
             server__hostname__in=servers_by_related.keys(),
             attribute=attribute,
-        ).select_related('server').defer(
+        ).prefetch_related('server').defer(
             'server__intern_ip',
             'server__servertype',
         ):

--- a/serveradmin/serverdb/views.py
+++ b/serveradmin/serverdb/views.py
@@ -8,9 +8,10 @@ import dateparser
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
@@ -37,16 +38,25 @@ def changes(request):
     date_settings = {'TIMEZONE': settings.TIME_ZONE}
 
     try:
-        object_id = request.GET.get('object_id') if not hostname else Server.objects.get(hostname=hostname).server_id
+        if hostname:
+            object_id = Server.objects.get(hostname=hostname).server_id
+        else:
+            object_id = request.GET.get('object_id')
     except ObjectDoesNotExist:
         messages.error(request, 'Server does not exist')
         return TemplateResponse(request, 'serverdb/changes.html', {})
 
     if t_from:
-        column_filter['change_on__gt'] = dateparser.parse(t_from, settings=date_settings)
+        column_filter['change_on__gt'] = dateparser.parse(
+            t_from,
+            settings=date_settings,
+        )
         context['from_understood'] = column_filter['change_on__gt']
     if t_until:
-        column_filter['change_on__lt'] = dateparser.parse(t_until, settings=date_settings)
+        column_filter['change_on__lt'] = dateparser.parse(
+            t_until,
+            settings=date_settings,
+        )
         context['until_understood'] = column_filter['change_on__lt']
     if object_id:
         q_filter.append((
@@ -59,7 +69,10 @@ def changes(request):
             Q(app__name=application) | Q(user__username=application)
         ))
 
-    commits = ChangeCommit.objects.filter(*q_filter, **column_filter).order_by('-change_on')
+    commits = ChangeCommit.objects.filter(
+        *q_filter,
+        **column_filter,
+    ).order_by('-change_on')
     paginator = Paginator(commits, 20)
 
     try:
@@ -87,9 +100,13 @@ def history(request):
     if not object_id:
         raise Http404
 
-    adds = ChangeAdd.objects.filter(server_id=object_id)
-    updates = ChangeUpdate.objects.filter(server_id=object_id)
-    deletes = ChangeDelete.objects.filter(server_id=object_id).select_related()
+    # TODO: Change data model so that server_id is moved to ChangeCommit.
+    #       To me this would make most sense. If that is not possible (why?!)
+    #       write a proper (custom) query that performs.
+    where = {'server_id': object_id}
+    adds = ChangeAdd.objects.filter(**where)
+    updates = ChangeUpdate.objects.filter(**where)
+    deletes = ChangeDelete.objects.filter(**where)
 
     # @TODO Transform to PostgreSQL JSON and put a index here
     if search_string:
@@ -97,27 +114,20 @@ def history(request):
         updates = updates.filter(updates_json__contains=search_string)
         deletes = deletes.filter(attributes_json__contains=search_string)
 
-    adds = adds.select_related()
-    updates = updates.select_related()
-
     if commit_id:
         adds = adds.filter(commit__pk=commit_id)
         updates = updates.filter(commit__pk=commit_id)
         deletes = deletes.filter(commit__pk=commit_id)
 
+    related = ('commit__app', 'commit__user')
+    adds = adds.select_related(*related)
+    updates = updates.select_related(*related)
+    deletes = deletes.select_related(*related)
+
     change_list = ([('add', obj) for obj in adds] +
                    [('update', obj) for obj in updates] +
                    [('delete', obj) for obj in deletes])
     change_list.sort(key=lambda entry: entry[1].commit.change_on, reverse=True)
-
-    for change in change_list:
-        commit = change[1].commit
-        if commit.user:
-            commit.commit_by = commit.user.get_full_name()
-        elif commit.app:
-            commit.commit_by = commit.app.name
-        else:
-            commit.commit_by = 'unknown'
 
     server = Server.objects.filter(server_id=object_id)
     return TemplateResponse(request, 'serverdb/history.html', {

--- a/serveradmin/serverdb/views.py
+++ b/serveradmin/serverdb/views.py
@@ -4,25 +4,25 @@ Copyright (c) 2019 InnoGames GmbH
 """
 
 import dateparser
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.db.models import Prefetch, Q
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 
 from serveradmin.serverdb.models import (
-    ChangeCommit,
     ChangeAdd,
-    ChangeUpdate,
+    ChangeCommit,
     ChangeDelete,
-    Server, ServertypeAttribute)
+    ChangeUpdate,
+    Server,
+    ServertypeAttribute,
+)
 from serveradmin.serverdb.query_committer import CommitError, commit_query
 
 


### PR DESCRIPTION
This PR heavily improves the performance of some aspects of Serveradmin with minimal effort.
1. Improves query times for queries involving relations and for nested queries.
2. Improves loading time of object history.

Query times were improved by ~40-45% and history loading times were improved by more than 90%.
While I still see lots of potential for further optimizations, I think with these minimal changes the gain is pretty massive.
Disclaimer: The improvements were calculated from my local instance :) I hope they will also be noticable as much on production.
See commit messages for all details.