### PR TITLE
Fix auto completion overrides (similar) previous attrs

### DIFF
--- a/serveradmin/servershell/static/js/servershell/autocomplete/search.js
+++ b/serveradmin/servershell/static/js/servershell/autocomplete/search.js
@@ -7,7 +7,8 @@
  */
 $(document).ready(function () {
     let _build_value = function (full_term, cur_term, attribute, value) {
-        let result = full_term.replace(cur_term, '') + attribute;
+        let cur_term_index = full_term.lastIndexOf(cur_term);
+        let result = full_term.substring(0, cur_term_index) + attribute;
         if (value) {
             result += `=${value}`;
         }


### PR DESCRIPTION
When building the results for the auto completion we take the full
entered search term and replace the entered term to complete with the
autocompleted part. Because we replace the first occurence this can break
if the term already contains similar words like for example
"game_market=de game_<autocomplete>".

This commit fixes it by easily search for the last occurence assuming
people only use auto completion at the end and don't jump to the
beginning of the search and enter something and expect auto completion.