### PR TITLE
Log profile time in ms and fixed format

### DIFF
--- a/serveradmin/common/utils.py
+++ b/serveradmin/common/utils.py
@@ -41,7 +41,7 @@ def profile(func):
         end = time.perf_counter()
 
         duration = end - start
-        msg = '%s processed in %s seconds' % (func.__name__, duration)
+        msg = '%s processed in %s ms' % (func.__name__, int(duration * 1000))
         logging.getLogger('profile').info(msg)
 
         return value


### PR DESCRIPTION
Avoid scientific representation such as 5.52e-05 to very small numbers
and log time in milliseconds.