### PR TITLE
Extend validation for inet attributes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -45,6 +45,8 @@ pex = "*"
 # Pex complains without requests
 requests = "*"
 setuptools = "*"
+# Generate fake data for tests
+faker = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd67e2fd5ac288bd1f19da30dc2d92736e488a8e555adf85fe2f06f1b7adecfd"
+            "sha256": "ce06ac9f329610e9c4aa788ca2fb8b5db6e232f55fde5e285dc7d4dd94a82eba"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -112,11 +112,11 @@
         },
         "django-compressor": {
             "hashes": [
-                "sha256:57ac0a696d061e5fc6fbc55381d2050f353b973fb97eee5593f39247bc0f30af",
-                "sha256:d2ed1c6137ddaac5536233ec0a819e14009553fee0a869bea65d03e5285ba74f"
+                "sha256:3358077605c146fdcca5f9eaffb50aa5dbe15f238f8854679115ebf31c0415e0",
+                "sha256:f8313f59d5e65712fc28787d084fe834997c9dfa92d064a1a3ec3d3366594d04"
             ],
             "index": "pypi",
-            "version": "==2.4"
+            "version": "==2.4.1"
         },
         "django-netfields": {
             "hashes": [
@@ -127,11 +127,10 @@
         },
         "gunicorn": {
             "hashes": [
-                "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626",
-                "sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"
+                "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"
             ],
             "index": "pypi",
-            "version": "==20.0.4"
+            "version": "==20.1.0"
         },
         "jinja2": {
             "hashes": [
@@ -224,42 +223,42 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:15306d71a1e96d7e271fd2a0737038b5a92ca2978d2e38b6ced7966583e3d5af",
-                "sha256:1940fc4d361f9cc7e558d6f56ff38d7351b53052fd7911f4b60cd7bc091ea3b1",
-                "sha256:1f93f2fe211f1ef75e6f589327f4d4f8545d5c8e826231b042b483d8383e8a7c",
-                "sha256:30d33a1a6400132e6f521640dd3f64578ac9bfb79a619416d7e8802b4ce1dd55",
-                "sha256:328240f7dddf77783e72d5ed79899a6b48bc6681f8d1f6001f55933cb4905060",
-                "sha256:46c2bcf8e1e75d154e78417b3e3c64e96def738c2a25435e74909e127a8cba5e",
-                "sha256:5762ebb4436f46b566fc6351d67a9b5386b5e5de4e58fdaa18a1c83e0e20f1a8",
-                "sha256:5a2d957eb4aba9d48170b8fe6538ec1fbc2119ffe6373782c03d8acad3323f2e",
-                "sha256:5cf03b9534aca63b192856aa601c68d0764810857786ea5da652581f3a44c2b0",
-                "sha256:5daba2b40782c1c5157a788ec4454067c6616f5a0c1b70e26ac326a880c2d328",
-                "sha256:63cd413ac52ee3f67057223d363f4f82ce966e64906aea046daf46695e3c8238",
-                "sha256:6efac40344d8f668b6c4533ae02a48d52fd852ef0654cc6f19f6ac146399c733",
-                "sha256:71b01ee69e7df527439d7752a2ce8fb89e19a32df484a308eca3e81f673d3a03",
-                "sha256:71f31ee4df3d5e0b366dd362007740106d3210fb6a56ec4b581a5324ba254f06",
-                "sha256:72027ebf682abc9bafd93b43edc44279f641e8996fb2945104471419113cfc71",
-                "sha256:74cd9aa648ed6dd25e572453eb09b08817a1e3d9f8d1bd4d8403d99e42ea790b",
-                "sha256:81b3716cc9744ffdf76b39afb6247eae754186838cedad0b0ac63b2571253fe6",
-                "sha256:8565355a29655b28fdc2c666fd9a3890fe5edc6639d128814fafecfae2d70910",
-                "sha256:87f42c976f91ca2fc21a3293e25bd3cd895918597db1b95b93cbd949f7d019ce",
-                "sha256:89e4c757a91b8c55d97c91fa09c69b3677c227b942fa749e9a66eef602f59c28",
-                "sha256:8c4e32218c764bc27fe49b7328195579581aa419920edcc321c4cb877c65258d",
-                "sha256:903293320efe2466c1ab3509a33d6b866dc850cfd0c5d9cc92632014cec185fb",
-                "sha256:90882c6f084ef68b71bba190209a734bf90abb82ab5e8f64444c71d5974008c6",
-                "sha256:98afcac3205d31ab6a10c5006b0cf040d0026a68ec051edd3517b776c1d78b09",
-                "sha256:a01da2c266d9868c4f91a9c6faf47a251f23b9a862dce81d2ff583135206f5be",
-                "sha256:aeab4cd016e11e7aa5cfc49dcff8e51561fa64818a0be86efa82c7038e9369d0",
-                "sha256:b07c660e014852d98a00a91adfbe25033898a9d90a8f39beb2437d22a203fc44",
-                "sha256:bead24c0ae3f1f6afcb915a057943ccf65fc755d11a1410a909c1fefb6c06ad1",
-                "sha256:d1d6bca39bb6dd94fba23cdb3eeaea5e30c7717c5343004d900e2a63b132c341",
-                "sha256:e2cd8ac157c1e5ae88b6dd790648ee5d2777e76f1e5c7d184eaddb2938594f34",
-                "sha256:e5739ae63636a52b706a0facec77b2b58e485637e1638202556156e424a02dc2",
-                "sha256:f36c3ff63d6fc509ce599a2f5b0d0732189eed653420e7294c039d342c6e204a",
-                "sha256:f91b50ad88048d795c0ad004abbe1390aa1882073b1dca10bfd55d0b8cf18ec5"
+                "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5",
+                "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4",
+                "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9",
+                "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a",
+                "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9",
+                "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727",
+                "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120",
+                "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c",
+                "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2",
+                "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797",
+                "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b",
+                "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f",
+                "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef",
+                "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232",
+                "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb",
+                "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9",
+                "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812",
+                "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178",
+                "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b",
+                "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5",
+                "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b",
+                "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1",
+                "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713",
+                "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4",
+                "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484",
+                "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c",
+                "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9",
+                "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388",
+                "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d",
+                "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602",
+                "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9",
+                "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e",
+                "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"
             ],
             "index": "pypi",
-            "version": "==8.1.2"
+            "version": "==8.2.0"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -453,6 +452,13 @@
             ],
             "version": "==0.7.12"
         },
+        "asgiref": {
+            "hashes": [
+                "sha256:92906c611ce6c967347bbfea733f13d6313901d54dcca88195eaeb52b2a8e8ee",
+                "sha256:d1216dfbdfb63826470995d31caed36225dcaf34f182e0fa257a4dd9e86f1b78"
+            ],
+            "version": "==3.3.4"
+        },
         "babel": {
             "hashes": [
                 "sha256:9d35c22fcc79893c3ecc85ac4a56cde1ecf3f19c540bba0922308a6c06ca6fa5",
@@ -474,20 +480,36 @@
             ],
             "version": "==4.0.0"
         },
-        "django-extensions": {
+        "django": {
             "hashes": [
-                "sha256:674ad4c3b1587a884881824f40212d51829e662e52f85b012cd83d83fe1271d9",
-                "sha256:9507f8761ee760748938fd8af766d0608fb2738cf368adfa1b2451f61c15ae35"
+                "sha256:2484f115891ab1a0e9ae153602a641fbc15d7894c036d79fb78662c0965d7954",
+                "sha256:2569f9dc5f8e458a5e988b03d6b7a02bda59b006d6782f4ea0fd590ed7336a64"
             ],
             "index": "pypi",
-            "version": "==3.1.1"
+            "version": "==2.2.20"
+        },
+        "django-extensions": {
+            "hashes": [
+                "sha256:081828e985485662f62a22340c1506e37989d14b927652079a5b7cd84a82368b",
+                "sha256:17f85f4dcdd5eea09b8c4f0bad8f0370bf2db6d03e61b431fa7103fee29888de"
+            ],
+            "index": "pypi",
+            "version": "==3.1.2"
         },
         "docutils": {
             "hashes": [
-                "sha256:a71042bb7207c03d5647f280427f14bfbd1a65c9eb84f4b341d85fafb6bb4bdf",
-                "sha256:e2ffeea817964356ba4470efba7c2f42b6b0de0b04e66378507e3e2504bbff4c"
+                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
+                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
-            "version": "==0.17"
+            "version": "==0.16"
+        },
+        "faker": {
+            "hashes": [
+                "sha256:26c7c3df8d46f1db595a34962f8967021dd90bbd38cc6e27461a3fb16cd413ae",
+                "sha256:44eb060fad3015690ff3fec6564d7171be393021e820ad1851d96cb968fbfcd4"
+            ],
+            "index": "pypi",
+            "version": "==8.1.0"
         },
         "idna": {
             "hashes": [
@@ -577,11 +599,11 @@
         },
         "pex": {
             "hashes": [
-                "sha256:988e6a4e12933522e0c647da78c6e30fc42e3a172ba52cfb0332affcfc9ee29e",
-                "sha256:c081bdd5d68dcb2f6efdc29e835ec08afba2d02a01ca5bdd7e47cd87cf6da8de"
+                "sha256:09130c1e74b67f2d248446b8d281a0e943957761fdf46f32c8485185bdb9c16a",
+                "sha256:9bef3c693b379a39a146237189dc5b502608b4710e82dac819bbb8f9e8194f9f"
             ],
             "index": "pypi",
-            "version": "==2.1.34"
+            "version": "==2.1.39"
         },
         "pygments": {
             "hashes": [
@@ -596,6 +618,13 @@
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
             "version": "==2.4.7"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
         },
         "pytz": {
             "hashes": [
@@ -612,6 +641,13 @@
             "index": "pypi",
             "version": "==2.25.1"
         },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "version": "==1.15.0"
+        },
         "snowballstemmer": {
             "hashes": [
                 "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2",
@@ -621,19 +657,19 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:672cfcc24b6b69235c97c750cb190a44ecd72696b4452acaf75c2d9cc78ca5ff",
-                "sha256:ef64a814576f46ec7de06adf11b433a0d6049be007fefe7fd0d183d28b581fac"
+                "sha256:19010b7b9fa0dc7756a6e105b2aacd3a80f798af3c25c273be64d7beeb482cb1",
+                "sha256:2320d4e994a191f4b4be27da514e46b3d6b420f2ff895d064f52415d342461e8"
             ],
             "index": "pypi",
-            "version": "==3.5.2"
+            "version": "==3.5.4"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:eda689eda0c7301a80cf122dad28b1861e5605cbf455558f3775e1e8200e83a5",
-                "sha256:fa6bebd5ab9a73da8e102509a86f3fcc36dec04a0b52ea80e5a033b2aba00113"
+                "sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a",
+                "sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f"
             ],
             "index": "pypi",
-            "version": "==0.5.1"
+            "version": "==0.5.2"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -676,6 +712,29 @@
                 "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
             ],
             "version": "==1.1.4"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0",
+                "sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8"
+            ],
+            "version": "==0.4.1"
+        },
+        "text-unidecode": {
+            "hashes": [
+                "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+                "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
+            ],
+            "version": "==1.3"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.7.4.3"
         },
         "urllib3": {
             "hashes": [

--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -106,6 +106,23 @@ If you see a login prompt, use the following user account:
 If not, consult your local Django expert ;)
 
 
+Testing your changes
+--------------------
+
+We have some tests which are executed when making a PR that you can already
+run locally to check if your changes are breaking anything existing. They are
+far from comprehensive at the time of writing this but can safe you some
+manual testing.
+
+You can execute the tests with the following commands
+
+    # Tests for the commandline interface: adminapi
+    pipenv run python -m unittest discover adminapi -v
+
+    # Tests for the backend code
+    pipenv run python -Wall -m serveradmin test --noinput --parallel
+
+
 Bonus: Setting up a cool debugger
 ---------------------------------
 

--- a/serveradmin/serverdb/admin.py
+++ b/serveradmin/serverdb/admin.py
@@ -31,6 +31,12 @@ class ServertypeAdmin(admin.ModelAdmin):
         ServertypeAttributeInline,
     )
 
+    def get_exclude(self, request, obj=None):
+        # Because of the great complexity when changing servertypes of existing
+        # objects and the little use-cases we have we just deny it for now.
+        if obj:
+            return ['ip_addr_type']
+
 
 class ServerRelationAttributeInline(admin.TabularInline):
     model = ServerRelationAttribute

--- a/serveradmin/serverdb/fixtures/auth_user.json
+++ b/serveradmin/serverdb/fixtures/auth_user.json
@@ -1,0 +1,20 @@
+[
+    {
+          "model": "auth.user",
+          "pk": 1,
+          "fields": {
+              "password": "pbkdf2_sha256$150000$w82dDYYVQ5kk$tZWXPj0KeKhtxjKTINpZdaVBjvJit31vUvKnsc2KS3s=",
+              "last_login": "2021-04-16T09:25:40.336Z",
+              "is_superuser": true,
+              "username": "admin",
+              "first_name": "",
+              "last_name": "",
+              "email": "",
+              "is_staff": true,
+              "is_active": true,
+              "date_joined": "2020-11-05T12:42:44.952Z",
+              "groups": [],
+              "user_permissions": []
+          }
+    }
+]

--- a/serveradmin/serverdb/fixtures/ip_addr_type.json
+++ b/serveradmin/serverdb/fixtures/ip_addr_type.json
@@ -1,0 +1,165 @@
+[
+    {
+        "model": "serverdb.servertype",
+        "pk": "host",
+        "fields": {
+            "description": "ip_addr_type host",
+            "ip_addr_type": "host"
+        }
+    },
+    {
+        "model": "serverdb.servertype",
+        "pk": "loadbalancer",
+        "fields": {
+            "description": "ip_addr_type loadbalancer",
+            "ip_addr_type": "loadbalancer"
+        }
+    },
+    {
+        "model": "serverdb.servertype",
+        "pk": "network",
+        "fields": {
+            "description": "ip_addr_type network",
+            "ip_addr_type": "network"
+        }
+    },
+    {
+        "model": "serverdb.servertype",
+        "pk": "null",
+        "fields": {
+            "description": "ip_addr_type null",
+            "ip_addr_type": "null"
+        }
+    },
+    {
+        "model": "serverdb.servertype",
+        "pk": "other_network",
+        "fields": {
+            "description": "ip_addr_type network",
+            "ip_addr_type": "network"
+        }
+    },
+    {
+        "model": "serverdb.attribute",
+        "pk": "ip_config",
+        "fields": {
+            "type": "inet",
+            "multi": false,
+            "hovertext": "",
+            "group": "other",
+            "help_link": null,
+            "readonly": false,
+            "target_servertype": null,
+            "reversed_attribute": null,
+            "clone": false,
+            "regexp": "\\A.*\\Z"
+        }
+    },
+    {
+        "model": "serverdb.attribute",
+        "pk": "ip_config_new",
+        "fields": {
+            "type": "inet",
+            "multi": false,
+            "hovertext": "",
+            "group": "other",
+            "help_link": null,
+            "readonly": false,
+            "target_servertype": null,
+            "reversed_attribute": null,
+            "clone": false,
+            "regexp": "\\A.*\\Z"
+        }
+    },
+    {
+        "model": "serverdb.servertypeattribute",
+        "pk": 7,
+        "fields": {
+            "servertype": "loadbalancer",
+            "attribute": "ip_config",
+            "related_via_attribute": null,
+            "consistent_via_attribute": null,
+            "required": false,
+            "default_value": null,
+            "default_visible": false
+        }
+    },
+    {
+        "model": "serverdb.servertypeattribute",
+        "pk": 9,
+        "fields": {
+            "servertype": "network",
+            "attribute": "ip_config",
+            "related_via_attribute": null,
+            "consistent_via_attribute": null,
+            "required": false,
+            "default_value": null,
+            "default_visible": false
+        }
+    },
+    {
+        "model": "serverdb.servertypeattribute",
+        "pk": 12,
+        "fields": {
+            "servertype": "host",
+            "attribute": "ip_config",
+            "related_via_attribute": null,
+            "consistent_via_attribute": null,
+            "required": false,
+            "default_value": null,
+            "default_visible": false
+        }
+    },
+    {
+        "model": "serverdb.servertypeattribute",
+        "pk": 13,
+        "fields": {
+            "servertype": "other_network",
+            "attribute": "ip_config",
+            "related_via_attribute": null,
+            "consistent_via_attribute": null,
+            "required": false,
+            "default_value": null,
+            "default_visible": false
+        }
+    },
+    {
+        "model": "serverdb.servertypeattribute",
+        "pk": 14,
+        "fields": {
+            "servertype": "host",
+            "attribute": "ip_config_new",
+            "related_via_attribute": null,
+            "consistent_via_attribute": null,
+            "required": false,
+            "default_value": null,
+            "default_visible": false
+        }
+    },
+    {
+        "model": "serverdb.servertypeattribute",
+        "pk": 15,
+        "fields": {
+            "servertype": "loadbalancer",
+            "attribute": "ip_config_new",
+            "related_via_attribute": null,
+            "consistent_via_attribute": null,
+            "required": false,
+            "default_value": null,
+            "default_visible": false
+        }
+    },
+    {
+        "model": "serverdb.servertypeattribute",
+        "pk": 16,
+        "fields": {
+            "servertype": "network",
+            "attribute": "ip_config_new",
+            "related_via_attribute": null,
+            "consistent_via_attribute": null,
+            "required": false,
+            "default_value": null,
+            "default_visible": false
+        }
+    }
+]

--- a/serveradmin/serverdb/forms.py
+++ b/serveradmin/serverdb/forms.py
@@ -1,55 +1,35 @@
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import gettext as _
+
+from serveradmin.serverdb.models import ServertypeAttribute
 
 
 class ServertypeAdminForm(forms.ModelForm):
-    def clean(self):
-        if self.cleaned_data.get('ip_addr_type') == 'null':
-            supernet_and_required = self.instance.attributes.filter(
-                required=True,
-                attribute__type='supernet'
-            ).only('attriute_id').values_list('attribute_id', flat=True)
-            if supernet_and_required.exists():
-                raise ValidationError(_(
-                        'ip_addr_type for Servertype must not be "null" '
-                        'if any attribute of type supernet is required '
-                        'but %(attrs)s is/are!'
-                    ),
-                    code='invalid',
-                    params={
-                        'attrs': ','.join(supernet_and_required)
-                    })
-        super().clean()
+    pass
 
 
 class ServertypeAttributeAdminForm(forms.ModelForm):
-    def clean(self):
-        supernet_and_required = (
-            self.cleaned_data['attribute'].type == 'supernet' and
-            self.cleaned_data['servertype'].ip_addr_type == 'null' and
-            self.cleaned_data.get('required') is True
-        )
-        if supernet_and_required:
-            raise ValidationError(_(
-                    'Attributes of type %(type)s can not be required if '
-                    'ip_addr_type of Servertype is null!'
-                ),
-                code='invalid',
-                params={
-                    'attribute': self.cleaned_data['attribute'].attribute_id,
-                    'type': self.cleaned_data['attribute'].type,
-                })
+    class Meta:
+        model = ServertypeAttribute
+        fields = [
+            'attribute',
+            'related_via_attribute',
+            'consistent_via_attribute',
+            'required',
+            'default_value',
+            'default_visible',
+        ]
 
-        # It makes no sense to add inet attributes to hosts of ip_addr_type
-        # null because they would have to be empty anyways.
+    def clean(self):
+        # It makes no sense to add inet or supernet attributes to hosts of
+        # ip_addr_type null because they would have to be empty anyways.
         inet_attribute = (
-                self.cleaned_data['attribute'].type == 'inet' and
-                self.cleaned_data['servertype'].ip_addr_type == 'null'
+            self.cleaned_data['attribute'].type in ('inet', 'supernet') and
+            self.instance.servertype.ip_addr_type == 'null'
         )
         if inet_attribute:
-            raise ValidationError(_(
-                'Adding an attribute of type inet with ip_addr_type: null is'
-                ' not possible!'), code='invalid')
+            raise ValidationError(
+                'Adding an attribute of type inet or supernet when '
+                'ip_addr_type is null is not possible!')
 
         super().clean()

--- a/serveradmin/serverdb/forms.py
+++ b/serveradmin/serverdb/forms.py
@@ -40,4 +40,16 @@ class ServertypeAttributeAdminForm(forms.ModelForm):
                     'attribute': self.cleaned_data['attribute'].attribute_id,
                     'type': self.cleaned_data['attribute'].type,
                 })
+
+        # It makes no sense to add inet attributes to hosts of ip_addr_type
+        # null because they would have to be empty anyways.
+        inet_attribute = (
+                self.cleaned_data['attribute'].type == 'inet' and
+                self.cleaned_data['servertype'].ip_addr_type == 'null'
+        )
+        if inet_attribute:
+            raise ValidationError(_(
+                'Adding an attribute of type inet with ip_addr_type: null is'
+                ' not possible!'), code='invalid')
+
         super().clean()

--- a/serveradmin/serverdb/models.py
+++ b/serveradmin/serverdb/models.py
@@ -323,8 +323,9 @@ class Server(models.Model):
             intern_ip__net_contains_or_equals=self.intern_ip,
         )
 
-    def clean(self, *args, **kwargs):
-        super(Server, self).clean(*args, **kwargs)
+    def clean(self):
+        super(Server, self).clean()
+
         if self.servertype.ip_addr_type == 'null':
             if self.intern_ip is not None:
                 raise ValidationError('IP address must be null.')

--- a/serveradmin/serverdb/models.py
+++ b/serveradmin/serverdb/models.py
@@ -14,7 +14,7 @@ from netaddr import EUI
 from django.db import models
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
-from django.utils.timezone import now, utc
+from django.utils.timezone import now
 from django.contrib.auth.models import User
 
 import netfields

--- a/serveradmin/serverdb/models.py
+++ b/serveradmin/serverdb/models.py
@@ -38,10 +38,10 @@ ATTRIBUTE_TYPES = {
 }
 
 IP_ADDR_TYPES = [
-    ('null', 'null (intern_ip must be empty and inet attributes not be used)'),
-    ('host', 'host (intern_ip must be a host /32,/128 and unique)'),
-    ('loadbalancer', 'loadbalancer (intern_ip must be a host /32,/128)'),
-    ('network', 'network (intern_ip must be a network and not overlap)'),
+    ('null', 'null: intern_ip must be empty, no inet attributes'),
+    ('host', 'host: intern_ip and inet must be an ip address and unique across all objects'),
+    ('loadbalancer', 'loadbalancer: intern_ip and inet must be an ip address'),
+    ('network', 'network: intern_ip and inet must be an ip network, not overlapping with same servertype'),
 ]
 
 LOOKUP_ID_VALIDATORS = [

--- a/serveradmin/serverdb/models.py
+++ b/serveradmin/serverdb/models.py
@@ -1,6 +1,6 @@
 """Serveradmin - Core Models
 
-Copyright (c) 2019 InnoGames GmbH
+Copyright (c) 2021 InnoGames GmbH
 """
 
 import re

--- a/serveradmin/serverdb/models.py
+++ b/serveradmin/serverdb/models.py
@@ -424,6 +424,9 @@ class Server(models.Model):
                 raise ValidationError(
                     _('intern_ip must not be null'), code='missing value')
 
+            # TODO: This logic is duplicated to the ServerInetAttribute clean
+            #       method but can be removed when we remove the special
+            #       intern_ip.
             if ip_addr_type == 'host':
                 is_ip_address(self.intern_ip)
                 is_unique_ip(self.intern_ip)

--- a/serveradmin/serverdb/models.py
+++ b/serveradmin/serverdb/models.py
@@ -5,22 +5,23 @@ Copyright (c) 2021 InnoGames GmbH
 
 import re
 import json
+import netfields
 
-from distutils.util import strtobool
-from ipaddress import ip_address, ip_network
-
+from typing import Union
 from netaddr import EUI
+from distutils.util import strtobool
+from ipaddress import ip_address, ip_network, IPv4Interface, IPv6Interface
 
-from django.db import models
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
+from django.db import models
 from django.utils.timezone import now
-from django.contrib.auth.models import User
-
-import netfields
+from django.utils.translation import gettext as _
 
 from adminapi.datatype import STR_BASED_DATATYPES
 from serveradmin.apps.models import Application
+
 
 ATTRIBUTE_TYPES = {
     'string': str,
@@ -37,7 +38,7 @@ ATTRIBUTE_TYPES = {
 }
 
 IP_ADDR_TYPES = [
-    ('null', 'null (intern_ip must not be used)'),
+    ('null', 'null (intern_ip must be empty and inet attributes not be used)'),
     ('host', 'host (intern_ip must be a host /32,/128 and unique)'),
     ('loadbalancer', 'loadbalancer (intern_ip must be a host /32,/128)'),
     ('network', 'network (intern_ip must be a network and not overlap)'),
@@ -66,6 +67,91 @@ def get_choices(types):
     # but we don't need it.  We are zipping the tuple to itself
     # to use the same names.
     return zip(*([types] * 2))
+
+
+# TODO: Make validators out of the methods is_ip_address, is_unique and
+#       is_network and attach them to the model fields validators.
+def is_ip_address(ip_interface: Union[IPv4Interface, IPv6Interface]) -> None:
+    """Validate if IPv4/IPv6 address
+
+    Raises a ValidationError if the ip_address is not an IPv4 or IPv6Address
+
+    :param ip_interface:
+    :return:
+    """
+    prefix_length = ip_interface.network.prefixlen
+    max_prefix_length = ip_interface.network.max_prefixlen
+
+    if prefix_length != max_prefix_length:
+        raise ValidationError(
+            'Netmask length must be {0}'.format(max_prefix_length))
+
+
+def is_unique_ip(ip_interface: Union[IPv4Interface, IPv6Interface]) -> None:
+    """Validate if IPv4/IPv6 address is unique
+
+    Raises a ValidationError if intern_ip or any other attribute of type inet
+    with this ip_address already exists.
+
+    :param ip_interface:
+    :return:
+    """
+
+    # We avoid querying the duplicate hosts here and giving the user
+    # detailed information because checking with exists is cheaper than
+    # querying the server and this is a validation and should be fast.
+    has_duplicates = (
+        Server.objects.filter(intern_ip=ip_interface).exclude(
+            servertype__ip_addr_type='network').exists() or
+        ServerInetAttribute.objects.filter(value=ip_interface).exclude(
+            server__servertype__ip_addr_type='network').exists())
+    if has_duplicates:
+        raise ValidationError(
+            'An object with {0} already exists'.format(str(ip_interface)))
+
+
+def is_network(ip_interface: Union[IPv4Interface, IPv6Interface]) -> None:
+    """Validate if IPv4/IPv6 interface is a network
+
+    Raise ValidationError if the given ip_interface is not a valid ip network.
+    Mind that e.g. 192.168.0.1 or 192.168.0.1/32 are valid ip networks.
+
+    :param ip_interface:
+    :return:
+    """
+
+    try:
+        ip_network(ip_interface)
+    except ValueError as error:
+        raise ValidationError(str(error))
+
+
+def network_overlaps(
+        ip_interface: Union[IPv4Interface, IPv6Interface],
+        servertype_id: str,
+) -> None:
+    """Validate if network overlaps with other objects of the servertype_id
+
+    Raises a ValidationError if the ip network overlaps with any other existing
+    objects network of the given servertype.
+
+    :param ip_interface:
+    :param servertype_id:
+    :return:
+    """
+
+    overlaps = (
+        Server.objects.filter(
+            servertype=servertype_id,
+            intern_ip__net_overlaps=ip_interface).exists() or
+        ServerInetAttribute.objects.filter(
+            server__servertype=servertype_id,
+            value__net_overlaps=ip_interface).exists()
+    )
+    if overlaps:
+        raise ValidationError(
+            '{0} overlaps with network of another object'.format(
+                str(ip_interface)))
 
 
 class Servertype(models.Model):
@@ -326,17 +412,26 @@ class Server(models.Model):
     def clean(self):
         super(Server, self).clean()
 
-        if self.servertype.ip_addr_type == 'null':
+        ip_addr_type = self.servertype.ip_addr_type
+        if ip_addr_type == 'null':
             if self.intern_ip is not None:
-                raise ValidationError('IP address must be null.')
+                raise ValidationError(
+                    _('intern_ip must be null'), code='invalid value')
         else:
+            # This is special to intern_ip for inet attributes this is covered
+            # by making them required.
             if self.intern_ip is None:
-                raise ValidationError('IP address must not be null.')
+                raise ValidationError(
+                    _('intern_ip must not be null'), code='missing value')
 
-            if self.servertype.ip_addr_type == 'network':
-                self._validate_network_intern_ip()
-            else:
-                self._validate_host_intern_ip()
+            if ip_addr_type == 'host':
+                is_ip_address(self.intern_ip)
+                is_unique_ip(self.intern_ip)
+            elif ip_addr_type == 'loadbalancer':
+                is_ip_address(self.intern_ip)
+            elif ip_addr_type == 'network':
+                is_network(self.intern_ip)
+                network_overlaps(self.intern_ip, self.servertype.servertype_id)
 
     def _validate_host_intern_ip(self):
         if self.intern_ip.max_prefixlen != self.netmask_len():
@@ -570,6 +665,28 @@ class ServerInetAttribute(ServerAttribute):
         db_table = 'server_inet_attribute'
         unique_together = [['server', 'attribute', 'value']]
         index_together = [['attribute', 'value']]
+
+    def clean(self):
+        super(ServerAttribute, self).clean()
+
+        # Get the ip_addr_type of the servertype
+        ip_addr_type = self.server.servertype.ip_addr_type
+
+        if ip_addr_type == 'null':
+            # A Servertype with ip_addr_type "null" and attributes of type
+            # inet must be denied per configuration. This is just a safety net
+            # in case e.g. somebody creates them programmatically.
+            raise ValidationError(
+                _('%(attribute_id)s must be null'), code='invalid value',
+                params={'attribute_id': self.attribute_id})
+        elif ip_addr_type == 'host':
+            is_ip_address(self.value)
+            is_unique_ip(self.value)
+        elif ip_addr_type == 'loadbalancer':
+            is_ip_address(self.value)
+        elif ip_addr_type == 'network':
+            is_network(self.value)
+            network_overlaps(self.value, self.server.servertype_id)
 
 
 class ServerMACAddressAttribute(ServerAttribute):

--- a/serveradmin/serverdb/query_committer.py
+++ b/serveradmin/serverdb/query_committer.py
@@ -81,6 +81,25 @@ def commit_query(created=[], changed=[], deleted=[], app=None, user=None):
 
         deleted_servers = _fetch_servers(deleted)
         deleted_objects = _materialize(deleted_servers, joined_attributes)
+        # TODO: Refactor validation
+        #
+        # This methods calls a set of functions to validate if changes to
+        # objects are valid. Additionally there is some extra validation in
+        # in _create_servers. Parts of this validation is shared and currently
+        # missing in the _create_servers validation (e.g. setting values for
+        # read-only attributes).
+        #
+        # We should refactor and fix this. Maybe we can use the standard forms
+        # API here by implementing some custom validators and building forms
+        # for the servertypes on-the-fly as described here:
+        #
+        #   - https://docs.djangoproject.com/en/2.2/ref/forms/validation/
+        #
+        # This would allow us to work with Django board tools and all it's
+        # features. Less pain because we always work around or even clash
+        # with the Django work flow and last but least allow us to use the
+        # same logic/code for the Servershell (edit, new) page and the Query
+        # engine (Web API) which currently does not use forms at all.
         _validate(attribute_lookup, changed, unchanged_objects)
 
         # Changes should be applied in order to prevent integrity errors.

--- a/serveradmin/serverdb/tests/test_ip_addr_type.py
+++ b/serveradmin/serverdb/tests/test_ip_addr_type.py
@@ -1,0 +1,455 @@
+"""Serveradmin - ip_addr_type validation tests
+
+Copyright (c) 2021 InnoGames GmbH
+"""
+
+import logging
+
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.test.testcases import TransactionTestCase
+from faker import Faker
+from faker.providers import internet
+
+from serveradmin.dataset import Query, DatasetObject
+from serveradmin.serverdb.forms import ServertypeAttributeAdminForm
+from serveradmin.serverdb.models import ServertypeAttribute
+
+# TODO: Remove "InternIp" classes when intern_ip is gone.
+#
+# Once we eliminated the special attribute intern_ip we can get rid of the
+# test classes with "InternIp" in name.
+
+
+class TestIpAddrType(TransactionTestCase):
+    fixtures = ['auth_user.json', 'ip_addr_type.json']
+
+    @classmethod
+    def setUpClass(cls):
+        logging.getLogger('faker').setLevel(logging.ERROR)
+
+    def setUp(self):
+        self.faker = Faker()
+        self.faker.add_provider(internet)
+
+    def _get_server(self, servertype: str) -> DatasetObject:
+        server = Query().new_object(servertype)
+        server['hostname'] = self.faker.hostname()
+
+        return server
+
+
+class TestIpAddrTypeNullForInternIp(TestIpAddrType):
+    """Most important tests for ip_addr_type null and intern_ip"""
+
+    def test_server_without_intern_ip(self):
+        server = self._get_server('null')
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_intern_ip(self):
+        server = self._get_server('null')
+        server['intern_ip'] = '10.0.0.1'
+
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+
+class TestIpAddrTypeNullForInetAttributes(TestIpAddrType):
+    """Most important tests for ip_addr_type null and inet attributes"""
+
+    def test_add_inet_attribute_in_admin_panel(self):
+        attr = ServertypeAttribute(
+            attribute_id='ip_config', servertype_id='null')
+        form = ServertypeAttributeAdminForm(
+            data={
+                'attribute': 'ip_config',
+                'servertype': 'null',
+            }, instance=attr)
+        form.is_valid()
+        with self.assertRaises(ValidationError):
+            form.clean()
+
+
+class TestIpAddrTypeHostForInternIp(TestIpAddrType):
+    """Most important tests for ip_addr_type host and intern_ip"""
+
+    def test_server_without_value(self):
+        server = self._get_server('host')
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_value(self):
+        server = self._get_server('host')
+        server['intern_ip'] = '10.0.0.1/32'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_invalid_value(self):
+        server = self._get_server('host')
+        server['intern_ip'] = 'nonsense'
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_ip_network(self):
+        server = self._get_server('host')
+        server['intern_ip'] = '10.0.0.0/16'
+
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_duplicate_intern_ip(self):
+        first = self._get_server('host')
+        first['intern_ip'] = '10.0.0.1/32'
+        first.commit(user=User.objects.first())
+
+        second = self._get_server('host')
+        second['intern_ip'] = '10.0.0.1'
+
+        with self.assertRaises(ValidationError):
+            second.commit(user=User.objects.first())
+
+    def test_server_with_duplicate_inet_ip(self):
+        first = self._get_server('host')
+        first['intern_ip'] = '10.0.0.1/32'
+        first['ip_config'] = '10.0.0.2/32'
+        first.commit(user=User.objects.first())
+
+        # Test "cross" duplicate attribute denial
+        duplicate = self._get_server('host')
+        duplicate['intern_ip'] = '10.0.0.2/32'
+        with self.assertRaises(ValidationError):
+            duplicate.commit(user=User.objects.first())
+
+
+class TestIpAddrTypeHostForInetAttributes(TestIpAddrType):
+    """Most important tests for ip_addr_type host and inet attributes"""
+
+    def test_server_without_value(self):
+        server = self._get_server('host')
+        server['intern_ip'] = '10.0.0.1/32'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_value(self):
+        server = self._get_server('host')
+        server['intern_ip'] = '10.0.0.1/32'
+        server['ip_config'] = '10.0.0.2/32'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_invalid_value(self):
+        server = self._get_server('host')
+        server['intern_ip'] = '10.0.0.1/32'
+        server['ip_config'] = 'nonsense'
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_ip_network(self):
+        server = self._get_server('host')
+        server['intern_ip'] = '10.0.0.1/32'
+        server['ip_config'] = '10.0.0.0/16'
+
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_duplicate_inet_attribute(self):
+        first = self._get_server('host')
+        first['intern_ip'] = '10.0.0.1/32'
+        first['ip_config'] = '10.0.0.2/32'
+        first.commit(user=User.objects.first())
+
+        second = self._get_server('host')
+        second['intern_ip'] = '10.0.0.3/32'
+        second['ip_config'] = '10.0.0.2/32'
+
+        with self.assertRaises(ValidationError):
+            second.commit(user=User.objects.first())
+
+    def test_server_overlaps_with_network(self):
+        network = self._get_server('network')
+        network['intern_ip'] = '10.0.0.5/32'
+        network['ip_config'] = '10.0.1.5/32'
+        network.commit(user=User.objects.first())
+
+        # An ip_address must not collide with the smallest possible network
+        server = self._get_server('host')
+        server['intern_ip'] = '10.0.0.1/32'
+        server['ip_config'] = '10.0.1.5/32'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_duplicate_intern_ip(self):
+        first = self._get_server('host')
+        first['intern_ip'] = '10.0.0.1/32'
+        first['ip_config'] = '10.0.0.2/32'
+        first.commit(user=User.objects.first())
+
+        # Test "cross" duplicate attribute denial
+        duplicate = self._get_server('host')
+        duplicate['intern_ip'] = '10.0.0.3/32'
+        duplicate['ip_config'] = '10.0.0.1/32'
+        with self.assertRaises(ValidationError):
+            duplicate.commit(user=User.objects.first())
+
+    def test_server_with_duplicate_inet_different_attrs(self):
+        server = self._get_server('host')
+        server['intern_ip'] = '10.0.0.1/32'
+        server['ip_config'] = '10.0.0.2/32'
+        server.commit(user=User.objects.first())
+
+        duplicate = self._get_server('host')
+        duplicate['intern_ip'] = '10.0.0.3/32'
+        duplicate['ip_config_new'] = '10.0.0.2/32'
+        with self.assertRaises(ValidationError):
+            duplicate.commit(user=User.objects.first())
+
+    def test_server_with_duplicate_inet_for_loadbalancer(self):
+        server = self._get_server('loadbalancer')
+        server['intern_ip'] = '10.0.0.1/32'
+        server.commit(user=User.objects.first())
+
+        duplicate = self._get_server('host')
+        duplicate['intern_ip'] = '10.0.0.2/32'
+        duplicate['ip_config'] = '10.0.0.1/32'
+        with self.assertRaises(ValidationError):
+            duplicate.commit(user=User.objects.first())
+
+
+class TestIpAddrTypeLoadbalancerForInternIp(TestIpAddrType):
+    """Most important tests for ip_addr_type loadbalancer and intern_ip"""
+
+    def test_server_without_value(self):
+        server = self._get_server('loadbalancer')
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_value(self):
+        server = self._get_server('loadbalancer')
+        server['intern_ip'] = '10.0.0.1/32'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_ip_network(self):
+        server = self._get_server('loadbalancer')
+        server['intern_ip'] = '10.0.0.0/16'
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_duplicate_intern_ip(self):
+        first = self._get_server('loadbalancer')
+        first['intern_ip'] = '10.0.0.1/32'
+        first.commit(user=User.objects.first())
+
+        second = self._get_server('loadbalancer')
+        second['intern_ip'] = '10.0.0.1/32'
+        self.assertIsNone(second.commit(user=User.objects.first()))
+
+
+class TestIpAddrTypeLoadbalancerForInetAttributes(TestIpAddrType):
+    """Most important tests for ip_addr_type loadbalancer and inet attrs"""
+
+    def test_server_without_value(self):
+        server = self._get_server('loadbalancer')
+        server['intern_ip'] = '10.0.0.1/32'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_value(self):
+        server = self._get_server('loadbalancer')
+        server['intern_ip'] = '10.0.0.1/32'
+        server['ip_config'] = '10.0.0.2/32'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_ip_network(self):
+        server = self._get_server('loadbalancer')
+        server['intern_ip'] = '10.0.0.1/32'
+        server['ip_config'] = '10.0.0.0/16'
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_duplicate_inet_attribute(self):
+        first = self._get_server('loadbalancer')
+        first['intern_ip'] = '10.0.0.1/32'
+        first['ip_config'] = '10.0.0.2/32'
+        first.commit(user=User.objects.first())
+
+        second = self._get_server('loadbalancer')
+        second['intern_ip'] = '10.0.0.1/32'
+        second['ip_config'] = '10.0.0.2/32'
+        self.assertIsNone(second.commit(user=User.objects.first()))
+
+    def test_server_with_duplicate_inet_ip(self):
+        first = self._get_server('loadbalancer')
+        first['intern_ip'] = '10.0.0.1/32'
+        first['ip_config'] = '10.0.0.2/32'
+        first.commit(user=User.objects.first())
+
+        # Test "cross" duplicate attribute is denied
+        duplicate = self._get_server('host')
+        duplicate['intern_ip'] = '10.0.0.2/32'
+        duplicate['ip_config'] = '10.0.0.1/32'
+        with self.assertRaises(ValidationError):
+            duplicate.commit(user=User.objects.first())
+
+    def test_server_with_duplicate_inet_different_attrs(self):
+        server = self._get_server('loadbalancer')
+        server['intern_ip'] = '10.0.0.1/32'
+        server['ip_config'] = '10.0.0.2/32'
+        server.commit(user=User.objects.first())
+
+        duplicate = self._get_server('loadbalancer')
+        duplicate['intern_ip'] = '10.0.0.3/32'
+        duplicate['ip_config_new'] = '10.0.0.2/32'
+        self.assertIsNone(duplicate.commit(user=User.objects.first()))
+
+
+class TestIpAddrTypeNetworkForInternIp(TestIpAddrType):
+    """Most important tests for ip_addr_type network and intern_ip"""
+
+    def test_server_without_value(self):
+        server = self._get_server('network')
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_value(self):
+        server = self._get_server('network')
+        server['intern_ip'] = '10.0.0.0/16'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_invalid_value(self):
+        server = self._get_server('host')
+        server['intern_ip'] = 'nonsense'
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_invalid_network(self):
+        server = self._get_server('network')
+        server['intern_ip'] = '10.0.0.5/16'  # Invalid: Has host bits set
+
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_ip_address(self):
+        server = self._get_server('network')
+        server['intern_ip'] = '10.0.0.1/32'  # Just a very small network
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_network_overlaps(self):
+        first = self._get_server('network')
+        first['intern_ip'] = '10.0.0.0/30'
+        first.commit(user=User.objects.first())
+
+        overlaps = self._get_server('network')
+        overlaps['intern_ip'] = '10.0.0.0/28'
+        with self.assertRaises(ValidationError):
+            overlaps.commit(user=User.objects.first())
+
+    def test_server_network_overlaps_inet(self):
+        first = self._get_server('network')
+        first['intern_ip'] = '10.0.0.0/30'
+        first['ip_config'] = '10.0.1.0/30'
+        first.commit(user=User.objects.first())
+
+        overlaps = self._get_server('network')
+        overlaps['intern_ip'] = '10.0.1.0/28'
+        with self.assertRaises(ValidationError):
+            overlaps.commit(user=User.objects.first())
+
+    def test_server_network_overlaps_other_servertype(self):
+        first = self._get_server('network')
+        first['intern_ip'] = '10.0.0.0/30'
+        first.commit(user=User.objects.first())
+
+        # A network can overlap with networks of other servertypes
+        overlaps = self._get_server('other_network')
+        overlaps['intern_ip'] = '10.0.0.0/28'
+        self.assertIsNone(overlaps.commit(user=User.objects.first()))
+
+
+class TestIpAddrTypeNetworkForInetAttributes(TestIpAddrType):
+    """Most important tests for ip_addr_type network and inet attrs"""
+
+    def test_server_without_value(self):
+        server = self._get_server('network')
+        server['intern_ip'] = '10.0.0.0/16'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_value(self):
+        server = self._get_server('network')
+        server['intern_ip'] = '10.0.0.0/30'
+        server['ip_config'] = '10.0.1.0/30'
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_with_invalid_value(self):
+        server = self._get_server('host')
+        server['intern_ip'] = '10.0.0.0/30'
+        server['ip_config'] = 'nonsense'
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_invalid_network(self):
+        server = self._get_server('network')
+        server['intern_ip'] = '10.0.0.0/16'
+        server['ip_config'] = '10.0.1.5/28'  # Invalid: Has host bits set
+
+        with self.assertRaises(ValidationError):
+            server.commit(user=User.objects.first())
+
+    def test_server_with_ip_address(self):
+        server = self._get_server('network')
+        server['intern_ip'] = '10.0.0.1/32'  # Just a very small network
+        server['ip_config'] = '10.0.1.0/32'  # Just a very small network
+        self.assertIsNone(server.commit(user=User.objects.first()))
+
+    def test_server_network_overlaps(self):
+        first = self._get_server('network')
+        first['intern_ip'] = '10.0.0.0/30'
+        first['ip_config'] = '10.0.1.0/30'
+        first.commit(user=User.objects.first())
+
+        overlaps = self._get_server('network')
+        overlaps['intern_ip'] = '10.0.3.0/30'
+        overlaps['ip_config'] = '10.0.1.0/28'
+        with self.assertRaises(ValidationError):
+            overlaps.commit(user=User.objects.first())
+
+    def test_server_network_overlaps_intern_ip(self):
+        first = self._get_server('network')
+        first['intern_ip'] = '10.0.0.0/30'
+        first.commit(user=User.objects.first())
+
+        overlaps = self._get_server('network')
+        overlaps['intern_ip'] = '10.0.1.0/28'
+        overlaps['ip_config'] = '10.0.0.0/28'
+        with self.assertRaises(ValidationError):
+            overlaps.commit(user=User.objects.first())
+
+    def test_server_network_is_equal(self):
+        first = self._get_server('network')
+        first['intern_ip'] = '10.0.0.0/30'
+        first['ip_config'] = '10.0.1.0/30'
+        first.commit(user=User.objects.first())
+
+        equal = self._get_server('network')
+        equal['intern_ip'] = '10.0.2.0/30'
+        equal['ip_config'] = '10.0.1.0/30'
+        with self.assertRaises(ValidationError):
+            equal.commit(user=User.objects.first())
+
+    def test_server_network_overlaps_other_servertype(self):
+        first = self._get_server('network')
+        first['intern_ip'] = '10.0.0.0/30'
+        first['ip_config'] = '10.0.1.0/30'
+        first.commit(user=User.objects.first())
+
+        # A network can overlap with networks of other servertypes
+        overlaps = self._get_server('other_network')
+        overlaps['intern_ip'] = '10.0.0.0/28'
+        overlaps['ip_config'] = '10.0.1.0/30'
+        self.assertIsNone(overlaps.commit(user=User.objects.first()))
+
+    def test_server_with_duplicate_inet_different_attrs(self):
+        server = self._get_server('network')
+        server['intern_ip'] = '10.0.0.0/30'
+        server['ip_config'] = '10.0.1.0/30'
+        server.commit(user=User.objects.first())
+
+        duplicate = self._get_server('network')
+        duplicate['intern_ip'] = '10.0.2.0/30'
+        duplicate['ip_config_new'] = '10.0.1.0/30'
+        with self.assertRaises(ValidationError):
+            duplicate.commit(user=User.objects.first())


### PR DESCRIPTION
For historical reasons we had validation only for the special attribute intern_ip but no (conistent) validation for intern_ip and inet attribute itself and together (combination). This PR aims to bring a consistent validation behaviour for all inet attributes and the special attribute intern_ip based on the ip_addr_type configuration of a servertype.

It includes tests and some comment on how we can further cleanup this when we refactor the validation and get rid of the special intern_ip later.