### PR TITLE
Specify prefix length for ip addresses of inet attributes

### DIFF
--- a/serveradmin/serverdb/query_materializer.py
+++ b/serveradmin/serverdb/query_materializer.py
@@ -16,7 +16,7 @@ from serveradmin.serverdb.models import (
     ServertypeAttribute,
     Server,
     ServerAttribute,
-    ServerRelationAttribute,
+    ServerRelationAttribute, inet_to_python,
 )
 
 
@@ -276,10 +276,11 @@ class QueryMaterializer:
                     yield attribute.attribute_id, None
                 else:
                     if servertype.ip_addr_type in ('host', 'loadbalancer'):
-                        yield attribute.attribute_id, value.ip
+                        yield attribute.attribute_id, inet_to_python(value.ip)
                     else:
                         assert servertype.ip_addr_type == 'network'
-                        yield attribute.attribute_id, value.network
+                        yield attribute.attribute_id, inet_to_python(
+                            value.network)
             elif value is None:
                 yield attribute.attribute_id, None
             elif attribute in join_results:


### PR DESCRIPTION
Ensure we always work with IPv4/IPv6Interface data types for both IP addresses and networks in the backend and adminapi and return ip addresses with prefix length (e.g. `10.0.0.1/32` instead of `10.0.0.1`) for the Web API.