### PR TITLE
Fix quotes in search term are HTML escaped

### DIFF
--- a/serveradmin/servershell/templates/servershell/index.html
+++ b/serveradmin/servershell/templates/servershell/index.html
@@ -193,8 +193,8 @@
 
         // Initialize servershell object properties with initial values
         // from backend. This allows us setting defaults from backend.
-        servershell.term = "{{ term }}";
-        servershell._term = "{{ term }}";
+        servershell.term = "{{ term|escapejs }}";
+        servershell._term = "{{ term|escapejs }}";
         servershell.command = "";
         servershell.understood = "";
         servershell.attributes = {% autoescape off %}{{ attributes|json }}{% endautoescape %};


### PR DESCRIPTION
The search term for the Servershell should be escaped for Javascript but
not for HTML. Otherwise when reloading the page we have an invalid
search term with HTML escape sequences.