### PR TITLE
Fix additional stylesheets in wrong template block

### DIFF
--- a/serveradmin/graphite/templates/graphite/graph_table.html
+++ b/serveradmin/graphite/templates/graphite/graph_table.html
@@ -4,7 +4,7 @@
     Graphs for {{ hostnames|join:", " }}
 {% endblock %}
 
-{% block additional_scripts %}
+{% block additional_styles %}
     <link rel="stylesheet" href="{{ STATIC_URL }}css/graphite.css">
 {% endblock %}
 


### PR DESCRIPTION
Stylesheets must go to the additional_style template block otherwise on
the-fly compression for CSS does not work.