### PR TITLE
Fix inet attribute overlaps with itself

### DIFF
--- a/serveradmin/serverdb/models.py
+++ b/serveradmin/serverdb/models.py
@@ -168,7 +168,10 @@ def network_overlaps(ip_interface: Union[IPv4Interface, IPv6Interface],
         ).exists() or
         ServerInetAttribute.objects.filter(
             server__servertype=servertype_id,
-            value__net_overlaps=ip_interface).exists()
+            value__net_overlaps=ip_interface
+        ).exclude(
+            server_id=object_id
+        ).exists()
     )
     if overlaps:
         raise ValidationError(


### PR DESCRIPTION
When changing an inet attribute it refuses to save when the new value
overlaps with the old one because it does not exlude itself.