### PR TITLE
Display ip_addr_type as read-only when editing

### DIFF
--- a/serveradmin/serverdb/admin.py
+++ b/serveradmin/serverdb/admin.py
@@ -38,7 +38,7 @@ class ServertypeAdmin(admin.ModelAdmin):
             # Because of the complexity when changing servertypes of existing
             # objects and the little use-cases we have right now we don't
             # support it.
-            fields = fields + tuple(['ip_addr_type'])
+            fields += ('ip_addr_type',)
 
         return fields
 

--- a/serveradmin/serverdb/admin.py
+++ b/serveradmin/serverdb/admin.py
@@ -31,11 +31,16 @@ class ServertypeAdmin(admin.ModelAdmin):
         ServertypeAttributeInline,
     )
 
-    def get_exclude(self, request, obj=None):
-        # Because of the great complexity when changing servertypes of existing
-        # objects and the little use-cases we have we just deny it for now.
+    def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj)
+
         if obj:
-            return ['ip_addr_type']
+            # Because of the complexity when changing servertypes of existing
+            # objects and the little use-cases we have right now we don't
+            # support it.
+            fields = fields + tuple(['ip_addr_type'])
+
+        return fields
 
 
 class ServerRelationAttributeInline(admin.TabularInline):


### PR DESCRIPTION
We still don't support changing the ip_addr_type of existing objects but
not being able to lookup the current type at all is not helpful so we
make it read-only in the edit form.