### PR TITLE
Allow bookmarking selection of attributes

### DIFF
--- a/serveradmin/servershell/static/js/servershell/autocomplete/command.js
+++ b/serveradmin/servershell/static/js/servershell/autocomplete/command.js
@@ -123,13 +123,15 @@ $(document).ready(function() {
                     command === 'delbookmark'
                 ) {
                     Object.keys(localStorage).forEach(function(key) {
-                        if (key.startsWith('bookmark.')) {
-                            const name = key.substr(9);
-                            choices.push({
-                                'label': `Bookmark: ${name}`,
-                                'value': `${command} ${name}`,
-                            });
+                        if (!key.startsWith('bookmark.')) {
+                            return;
                         }
+                        
+                        const name = key.substr(9);
+                        choices.push({
+                            'label': `Bookmark: ${name}`,
+                            'value': `${command} ${name}`,
+                        });
                     });
                 }
                 if (

--- a/serveradmin/servershell/static/js/servershell/autocomplete/command.js
+++ b/serveradmin/servershell/static/js/servershell/autocomplete/command.js
@@ -118,6 +118,21 @@ $(document).ready(function() {
                     });
                 }
                 if (
+                    command === 'bookmark' ||
+                    command === 'loadbookmark' ||
+                    command === 'delbookmark'
+                ) {
+                    Object.keys(localStorage).forEach(function(key) {
+                        if (key.startsWith('bookmark.')) {
+                            const name = key.substr(9);
+                            choices.push({
+                                'label': `Bookmark: ${name}`,
+                                'value': `${command} ${name}`,
+                            });
+                        }
+                    });
+                }
+                if (
                     command === 'orderby' ||
                     command === 'delattr' ||
                     command === 'history'

--- a/serveradmin/servershell/static/js/servershell/command.js
+++ b/serveradmin/servershell/static/js/servershell/command.js
@@ -235,6 +235,31 @@ servershell.commands = {
         // Now trigger reload with all changes at once
         servershell.shown_attributes = shown_attributes;
     },
+    bookmark: function(name) {
+        if (!name) {
+            servershell.alert('Missing name for bookmark', 'warning');
+            return;
+        }
+
+        localStorage.setItem('bookmark.' + name, servershell.shown_attributes);
+        servershell.alert(`Bookmark ${name} saved.`, 'success');
+    },
+    delbookmark: function(name) {
+        if (!name) {
+            servershell.alert('Missing name for bookmark', 'warning');
+            return;
+        }
+
+        localStorage.removeItem('bookmark.' + name);
+        servershell.alert(`Bookmark ${name} deleted.`, 'success');
+    },
+    loadbookmark: function(name) {
+        let attribute_ids = localStorage.getItem('bookmark.' + name);
+        if (attribute_ids) {
+            servershell.shown_attributes = attribute_ids.split(',');
+            servershell.alert(`Bookmark ${name} loaded.`, 'success');
+        }
+    },
     orderby: function(attribute_id) {
         if (!servershell.attributes.find(a => a.attribute_id === attribute_id)) {
             servershell.alert(`Attribute ${name} does not exist!`, 'warning');

--- a/serveradmin/servershell/templates/servershell/modals/help_command.html
+++ b/serveradmin/servershell/templates/servershell/modals/help_command.html
@@ -64,6 +64,46 @@
                                 </p>
                             </td>
                         </tr>
+                        <tr id="cmd-bookmark">
+                            <td>bookmark</td>
+                            <td>bookmark,[...]</td>
+                            <td>
+                                Save bookmark by name
+                                <p>
+                                    Save current selection of bookmarks by name.
+
+                                    Example:
+                                    "<code>bookmark firewall</code>"
+                                </p>
+                            </td>
+                        </tr>
+                        <tr id="cmd-loadbookmark">
+                            <td>loadbookmark</td>
+                            <td>loadbookmark,[...]</td>
+                            <td>
+                                Load bookmark
+                                <p>
+                                    Load selection of attributes with name
+                                    saved with bookmark command.
+
+                                    Example:
+                                    "<code>loadbookmark firewall</code>"
+                                </p>
+                            </td>
+                        </tr>
+                        <tr id="cmd-delbookmark">
+                            <td>delbookmark</td>
+                            <td>delbookmark,[...]</td>
+                            <td>
+                                Delete bookmark
+                                <p>
+                                    Delete bookmark with name.
+
+                                    Example:
+                                    "<code>delbookmark firewall</code>"
+                                </p>
+                            </td>
+                        </tr>
                         <tr id="cmd-orderby">
                             <td>orderby</td>
                             <td>attr_name</td>


### PR DESCRIPTION
Add a Servershell command that either saves the current selection of
attributes visible or loads them by a given name. The selection is
persisted in the local browser storage to avoid overhead in the backend.