### PR TITLE
Make type read-only for editing existing attributes

### DIFF
--- a/serveradmin/serverdb/admin.py
+++ b/serveradmin/serverdb/admin.py
@@ -59,7 +59,20 @@ class ServerAdmin(admin.ModelAdmin):
     )
 
 
+class AttributeAdmin(admin.ModelAdmin):
+    def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj)
+
+        # Because of the complexity when changing attribute types of existing
+        # objects and the little use-cases we have right now we don't
+        # support it.
+        if obj:
+            fields += ('type',)
+
+        return fields
+
+
 admin.site.register(Servertype, ServertypeAdmin)
-admin.site.register(Attribute)
+admin.site.register(Attribute, AttributeAdmin)
 admin.site.register(Server, ServerAdmin)
 admin.site.register(ChangeDelete)


### PR DESCRIPTION
Changing the attribute type of existing attributes can be a dangerous
operation because we don't have a defined behaviour for the existing
values so it is not really supported.

Techincally one could make changes to attribute types for existing
objects by e.g. writing a script that dumps the values, changes the
attribute type and then restores the values but this required deep
knowledge and is error prone so it is best to deny it in the first
place.

For know we handle such cases manually in the database and hopefully
come up with support for changing attribute types in a safe manner in
future.