### PR TITLE
Fix auto completion triggered after submit

### DIFF
--- a/serveradmin/servershell/static/js/servershell/autocomplete/command.js
+++ b/serveradmin/servershell/static/js/servershell/autocomplete/command.js
@@ -46,7 +46,7 @@ $(document).ready(function() {
     let command_input = $('#command');
 
     command_input.autocomplete({
-        minLength: 0,
+        minLength: 1,
         source: function(request, response) {
             let choices = [];
             let arguments = request.term.split(' ');


### PR DESCRIPTION
When the minimum length to trigger the auto completion is 0 it opens
when one selected a value and submits the value with enter because the
command field is reset and therefore empty - we don't want that.