### PR TITLE
Remove auto completion for attribute values

### DIFF
--- a/serveradmin/servershell/static/js/servershell/autocomplete/search.js
+++ b/serveradmin/servershell/static/js/servershell/autocomplete/search.js
@@ -70,28 +70,6 @@ $(document).ready(function () {
                         'value': new_term + '(',
                     });
                 });
-
-                // Autocomplete attribute value if wanted
-                // @TODO support nested values e.g. "project=Any(Reg("
-                if (servershell.search_settings.autocomplete_values) {
-                    // Add attribute values matching
-                    let settings = {
-                        'async': false,
-                        'data': {
-                            'attribute': attribute,
-                            'value': value,
-                        },
-                        'success': function (data) {
-                            data.autocomplete.forEach(function(match) {
-                                choices.push({
-                                    'label': `AttrVal: ${match}`,
-                                    'value': _build_value(request.term, to_complete, attribute, match),
-                                });
-                            });
-                        }
-                    };
-                    $.ajax(autocomplete_search_url, settings);
-                }
             }
 
             // Autocomplete attributes

--- a/serveradmin/servershell/static/js/servershell/search.js
+++ b/serveradmin/servershell/static/js/servershell/search.js
@@ -110,7 +110,6 @@ $(document).ready(function() {
     $('#search-options input').change(function() {
         $.getJSON(servershell.urls.settings, {
             'autocomplete': $('#autocomplete')[0].checked,
-            'autocomplete_values': $('#autocomplete_values')[0].checked,
             'autocomplete_delay_search': $('#autocomplete_delay_search').val(),
             'autocomplete_delay_commands': $('#autocomplete_delay_commands').val(),
             'autoselect': $('#autoselect')[0].checked,

--- a/serveradmin/servershell/templates/servershell/index.html
+++ b/serveradmin/servershell/templates/servershell/index.html
@@ -48,10 +48,6 @@
                         <label class="form-check-label" for="autocomplete">Autocomplete for Search & Command</label>
                     </div>
                     <div class="form-check">
-                        <input type="checkbox" class="form-check-input" id="autocomplete_values" {% if search_settings.autocomplete_values %}checked="checked{% endif %}">
-                        <label class="form-check-label" for="autocomplete_values">Autocomplete search attribute values (May be slow and override your input with autoselect enabled)</label>
-                    </div>
-                    <div class="form-check">
                         <input type="checkbox" class="form-check-input" id="autoselect" {% if search_settings.autoselect %}checked="checked{% endif %}" onchange="$('.autocomplete').autocomplete('option', 'autoFocus', this.checked);">
                         <label class="form-check-label" for="autoselect">Automatically select 1st element from autocomplete</label>
                     </div>

--- a/serveradmin/servershell/views.py
+++ b/serveradmin/servershell/views.py
@@ -53,7 +53,6 @@ NUM_SERVERS_DEFAULT = 25
 AUTOCOMPLETE_LIMIT = 20
 SEARCH_SETTINGS = {
     'autocomplete': True,
-    'autocomplete_values': False,
     'autocomplete_delay_search': 250,
     'autocomplete_delay_commands': 10,
     'autoselect': True,
@@ -113,7 +112,6 @@ def autocomplete(request):
     autocomplete_list = list()
     hostname = request.GET.get('hostname')
     attribute_id = request.GET.get('attribute')
-    attribute_val = request.GET.get('value')
 
     if hostname:
         try:
@@ -126,13 +124,8 @@ def autocomplete(request):
             pass
 
     if attribute_id:
-        if attribute_val:
-            autocomplete_list = attribute_value_startswith(attribute_id,
-                                                           attribute_val,
-                                                           AUTOCOMPLETE_LIMIT)
-        else:
-            autocomplete_list = attribute_startswith(attribute_id,
-                                                     AUTOCOMPLETE_LIMIT)
+        autocomplete_list = attribute_startswith(attribute_id,
+                                                 AUTOCOMPLETE_LIMIT)
 
     return HttpResponse(json.dumps({'autocomplete': autocomplete_list}),
                         content_type='application/x-json')


### PR DESCRIPTION
People seem not to use the auto completion for values and it can be
quite expensive (queries) so we remove it.