### PR TITLE
Fix alerts move result table up and down

### DIFF
--- a/serveradmin/servershell/static/css/servershell.css
+++ b/serveradmin/servershell/static/css/servershell.css
@@ -100,3 +100,9 @@
     left: -17px;
     margin-bottom: 0;
 }
+
+#alerts {
+    z-index: 100;
+    position: absolute;
+    width: 98%;
+}

--- a/serveradmin/servershell/static/js/servershell.js
+++ b/serveradmin/servershell/static/js/servershell.js
@@ -219,7 +219,7 @@ servershell.alert = function(text, level, auto_dismiss=5) {
     alert.addClass(`alert-${level}`);
     alert.children('.alert-text').text(text);
 
-    $('#alerts').append(alert);
+    $('#alerts').prepend(alert);
     alert.toggle();
 
     if (auto_dismiss > 0) {


### PR DESCRIPTION
Make alerts float over the content so that they don't move the result
table up and down.