### PR TITLE
Check signing capability using non-empty data

### DIFF
--- a/adminapi/request.py
+++ b/adminapi/request.py
@@ -79,7 +79,7 @@ def signable(key):
     """Checks if key is able to sign the message
     """
     try:
-        key.sign_ssh_data(b'')
+        key.sign_ssh_data(b'InnoGames')
         return True
     except SSHException:
         return False


### PR DESCRIPTION
When checking if a SSH key is capable of signing, we were trying to sign
an empty byte literal, that didn't work with the SSH-compatible GPG
agent. Trying key.sign_ssh_data(b'') with the GPG agent raised
paramiko.ssh_exception.SSHException: key cannot be used for signing,
while key.sign_ssh_data(b'InnoGames') worked just fine.