### PR TITLE
Fix /bin/sh: 1: sphinx-build: not found

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,4 +72,4 @@ jobs:
           pipenv run python -Wall -m serveradmin test --noinput --parallel
           # Build sphinx docs, error on warning
           cd docs
-          SPHINXOPTS='-W' pipenv run make html
+          SPHINXBUILD='pipenv run sphinx-build' SPHINXOPTS='-W' make html


### PR DESCRIPTION
It looks like we previously used the sphinx-build command of the
underlying os (ubuntu-latest) which is now gone. This change makes sure
we are using the one installed by Pipfile.