### PR TITLE
Be able to exclude changes matching a string

### DIFF
--- a/serveradmin/serverdb/templates/serverdb/history.html
+++ b/serveradmin/serverdb/templates/serverdb/history.html
@@ -19,6 +19,12 @@
                     <input name="search_string" id="search_string" type="text" value="{% if search_string %}{{ search_string }}{% endif %}" class="form-control form-control-sm" placeholder="Filter for ..." />
                 </div>
             </div>
+            <div class="form-group row input-controls">
+                <label for="exclude_string" class="col-sm-1 col-form-label">Excludes:</label>
+                <div class="col-md-4">
+                    <input name="exclude_string" id="exclude_string" type="text" value="{% if exclude_string %}{{ exclude_string }}{% endif %}" class="form-control form-control-sm" placeholder="Exclude ..." />
+                </div>
+            </div>
             <div class="form-group row input-controls buttons">
                 <input type="hidden" id="object_id" name="object_id" value="{{ object_id }}"/>
                 <input type="hidden" id="page" name="page" value="{{ changes.number }}" />

--- a/serveradmin/serverdb/views.py
+++ b/serveradmin/serverdb/views.py
@@ -96,6 +96,7 @@ def history(request):
     object_id = request.GET.get('object_id')
     commit_id = request.GET.get('commit_id')
     search_string = request.GET.get('search_string')
+    exclude_string = request.GET.get('exclude_string')
 
     if not object_id:
         raise Http404
@@ -113,6 +114,11 @@ def history(request):
         adds = adds.filter(attributes_json__contains=search_string)
         updates = updates.filter(updates_json__contains=search_string)
         deletes = deletes.filter(attributes_json__contains=search_string)
+
+    if exclude_string:
+        adds = adds.exclude(attributes_json__contains=exclude_string)
+        updates = updates.exclude(updates_json__contains=exclude_string)
+        deletes = deletes.exclude(attributes_json__contains=exclude_string)
 
     if commit_id:
         adds = adds.filter(commit__pk=commit_id)
@@ -139,6 +145,7 @@ def history(request):
         'base_template': 'empty.html' if request.is_ajax() else 'base.html',
         'link': request.get_full_path(),
         'search_string': search_string,
+        'exclude_string': exclude_string,
     })
 
 


### PR DESCRIPTION
It can be difficult to view the history of Serveradmin objects where
certain attributes are frequently changed (e.g. by a script).

Until the history becomes a jsonb type in PostgreSQL and we can filter
for specific attributes we work around this by matching strings.