### PR TITLE
Move alert box to the top right of the Servershell

### DIFF
--- a/serveradmin/servershell/static/css/servershell.css
+++ b/serveradmin/servershell/static/css/servershell.css
@@ -104,5 +104,7 @@
 #alerts {
     z-index: 100;
     position: absolute;
-    width: 98%;
+    width: 25%;
+    right: 0;
+    top: 1%;
 }


### PR DESCRIPTION
It is annoying when the alerts of the Servershell hide input fields so we move them to the top right.

**Before**
![before](https://user-images.githubusercontent.com/3993306/141321440-51e65a79-91bc-4900-9639-58a181517646.png)

**After**
![after](https://user-images.githubusercontent.com/3993306/141321460-11b04e03-c635-46df-a00a-5b320f53859a.png)
