### PR TITLE
Expand gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ __pycache__/
 
 # Virtual Environment
 /venv/
+
+# Nix-related
+/.envrc
+/default.nix


### PR DESCRIPTION
Managed to run the whole environment via nix-shell. These 2 are globally useless for git.