### PR TITLE
Fix restrict parameter of Query changed

### DIFF
--- a/adminapi/dataset.py
+++ b/adminapi/dataset.py
@@ -77,6 +77,9 @@ class BaseQuery(object):
                 raise TypeError('Restrict must be a list')
 
             if 'object_id' not in restrict:
+                # Don't change the original restrict to avoid the user working
+                # with unexpected elements.
+                restrict = restrict.copy()
                 restrict.append('object_id')
 
             return [


### PR DESCRIPTION
Do not change passed restrict parameter to Query object. The user might
work with this and not expect that it changes.