### PR TITLE
Remember attribute list status

### DIFF
--- a/serveradmin/servershell/static/js/servershell.js
+++ b/serveradmin/servershell/static/js/servershell.js
@@ -253,3 +253,23 @@ servershell.get_attribute = function(attribute_id) {
     return servershell.attributes.find(
         attribute => attribute.attribute_id === attribute_id);
 };
+
+/**
+ * Save the status of attributes list
+ */
+servershell.save_hidden_attrlist = function(element) {
+    localStorage.setItem('attrlist_hidden', (element.attributes["aria-expanded"]["nodeValue"] === 'true'));
+};
+
+/**
+ * Check the local storage and toggle attributes list
+ *
+ * If it's not defined or set to not hidden, it triggers collapse function
+ * to show. Otherwise it keeps it closed.
+ */
+servershell.sync_attrlist_visibility = function() {
+    let attribute_list_hidden = localStorage.getItem('attrlist_hidden');
+    if ( attribute_list_hidden === "false" || attribute_list_hidden === null ) {
+        $("#accordion-attributes-body").collapse('show');
+    };
+};

--- a/serveradmin/servershell/templates/servershell/index.html
+++ b/serveradmin/servershell/templates/servershell/index.html
@@ -105,9 +105,9 @@
                 <div class="card">
                     <div class="card-header">
                         <b>Attributes</b>
-                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#accordion-attributes-body"></button>
+                        <button class="btn btn-link collapsed" type="button" data-toggle="collapse" aria-expanded="false" data-target="#accordion-attributes-body" onclick="servershell.save_hidden_attrlist(this)"></button>
                     </div>
-                    <div id="accordion-attributes-body" class="component show" data-parent="#accordion-attributes">
+                    <div id="accordion-attributes-body" class="component collapsed collapse" data-parent="#accordion-attributes">
                         <div id="attributes" class="card-body">
                             <b>Legend:</b><br>
                             <span class="attribute-indicator">
@@ -230,6 +230,7 @@
         };
 
         servershell.search_settings = {% autoescape off %}{{ search_settings|json }}{% endautoescape %};
+        servershell.sync_attrlist_visibility();
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
Now we use localStorage to remember the state of attribute list. If it is unset, we don't change the default (shown).