### PR TITLE
Fix Attribute was modified despite being whitelisted

### DIFF
--- a/serveradmin/graphite/management/commands/cache_graphite.py
+++ b/serveradmin/graphite/management/commands/cache_graphite.py
@@ -5,6 +5,7 @@ Copyright (c) 2019 InnoGames GmbH
 
 import json
 from datetime import datetime
+from decimal import Decimal
 from os import mkdir
 from os.path import isdir
 import time
@@ -123,7 +124,7 @@ class Command(BaseCommand):
                 locked_server.servernumberattribute_set.update_or_create(
                     server_id=locked_server.server_id,
                     attribute=numeric.attribute,
-                    defaults={'value': value},
+                    defaults={'value': Decimal(value)},
                 )
 
     def get_from_graphite(self, params):

--- a/serveradmin/graphite/management/commands/cache_graphite.py
+++ b/serveradmin/graphite/management/commands/cache_graphite.py
@@ -4,24 +4,25 @@ Copyright (c) 2019 InnoGames GmbH
 """
 
 import json
+import time
 from datetime import datetime
 from decimal import Decimal
+from io import BytesIO
 from os import mkdir
 from os.path import isdir
-import time
-from PIL import Image
-from io import BytesIO
+from urllib.error import HTTPError
 from urllib.request import (
     HTTPBasicAuthHandler,
     HTTPPasswordMgrWithDefaultRealm,
     build_opener
 )
-from urllib.error import HTTPError
 
-from django.core.management.base import BaseCommand
+from PIL import Image
 from django.conf import settings
+from django.core.management.base import BaseCommand
 from django.db import transaction
 
+from adminapi import filters
 from serveradmin.dataset import Query
 from serveradmin.graphite.models import (
     GRAPHITE_ATTRIBUTE_ID,
@@ -29,7 +30,6 @@ from serveradmin.graphite.models import (
     AttributeFormatter,
 )
 from serveradmin.serverdb.models import Server
-from adminapi import filters
 
 
 class Command(BaseCommand):

--- a/serveradmin/graphite/management/commands/cache_graphite.py
+++ b/serveradmin/graphite/management/commands/cache_graphite.py
@@ -1,6 +1,6 @@
 """Serveradmin - Graphite Integration
 
-Copyright (c) 2019 InnoGames GmbH
+Copyright (c) 2022 InnoGames GmbH
 """
 
 import json

--- a/serveradmin/serverdb/query_committer.py
+++ b/serveradmin/serverdb/query_committer.py
@@ -119,6 +119,8 @@ def commit_query(created=[], changed=[], deleted=[], app=None, user=None):
         _upsert_attributes(attribute_lookup, changed, changed_servers)
         changed_objects = _materialize(changed_servers, joined_attributes)
 
+        # @TODO Improve this function by checking only attributes of ACLs that
+        #       have actually changed and not all.
         _access_control(
             user, app, unchanged_objects,
             created_objects, changed_objects, deleted_objects

--- a/serveradmin/serverdb/query_committer.py
+++ b/serveradmin/serverdb/query_committer.py
@@ -119,8 +119,8 @@ def commit_query(created=[], changed=[], deleted=[], app=None, user=None):
         _upsert_attributes(attribute_lookup, changed, changed_servers)
         changed_objects = _materialize(changed_servers, joined_attributes)
 
-        # @TODO Improve this function by checking only attributes of ACLs that
-        #       have actually changed and not all.
+        # TODO Improve this function by checking only attributes of ACLs that
+        #      have actually changed and not all.
         _access_control(
             user, app, unchanged_objects,
             created_objects, changed_objects, deleted_objects


### PR DESCRIPTION
When a query tries to commit changes it sometimes fails because the
command to cache graphite numeric has changed an attribute of this
server in the meantime.