### PR TITLE
Ignore newlines in query string

### DIFF
--- a/adminapi/parse.py
+++ b/adminapi/parse.py
@@ -10,6 +10,9 @@ _trigger_re_chars = ('.*', '.+', '[', ']', '|', '\\', '$', '^', '<')
 
 
 def parse_query(term, hostname=None):  # NOQA: C901
+    # Ignore newlines to allow queries across multiple lines
+    term = term.replace('\n', '')
+
     parsed_args = parse_function_string(term, strict=True)
     if not parsed_args:
         return {}


### PR DESCRIPTION
I can't think of a good reason to have newlines in a query string.
Removing them allows to type a query in the terminal across multiple
lines without changing the query.