### PR TITLE
Deny changing some Attribute fields

### DIFF
--- a/serveradmin/serverdb/admin.py
+++ b/serveradmin/serverdb/admin.py
@@ -87,7 +87,10 @@ class AttributeAdmin(admin.ModelAdmin):
         # objects and the little use-cases we have right now we don't
         # support it.
         if obj:
-            fields += ('type',)
+            fields += (
+                'type', 'attribute_id', 'target_servertype',
+                'reversed_attribute'
+            )
 
         return fields
 


### PR DESCRIPTION
Changing the attribute_id, target_servertype and reversed_attribute for
exsiting attributes can lead to inconsistencies when existing values are
not taken into account. We therefore deny it by default to avoid
thinking about it.