### PR TITLE
Display related as disabled in edit mode

### DIFF
--- a/serveradmin/servershell/templates/servershell/edit.html
+++ b/serveradmin/servershell/templates/servershell/edit.html
@@ -46,14 +46,14 @@
                         <td>
                             {% if field.multi %}
                                 <textarea class="edit_value" rows="3"  cols="70"  name="attr_{{ field.key }}"
-                                        {% if field.readonly %} disabled="disabled"{% endif %}
+                                        {% if field.readonly or field.type == 'related' %} disabled="disabled"{% endif %}
                                         {% if field.required %} required {% endif %}
                                         {% if field.regexp %}data-pattern="{{ field.regexp }}"{% endif %}
                                 >{% if field.value != None %}{{ field|field_to_str }}{% endif %}</textarea>
                             {% else %}
                                 <input class="edit_value"  type="text"  name="attr_{{ field.key }}"
                                        value="{% if field.value != None %}{{ field|field_to_str }}{% endif %}"
-                                       size="70" {% if field.readonly %}disabled="disabled" {% endif %}
+                                       size="70" {% if field.readonly or field.type == 'related' %}disabled="disabled" {% endif %}
                                        {% if field.regexp %}data-pattern="{{ field.regexp }}"{% endif %}
                                        {% if field.required %} required {% endif %}
                                        {% if field.key == 'intern_ip' %}readonly onclick="servershell.choose_ip_address();"{% endif %}

--- a/serveradmin/servershell/views.py
+++ b/serveradmin/servershell/views.py
@@ -353,10 +353,7 @@ def _edit(request, server, edit_mode=False, template='edit'):  # NOQA: C901
             servertype_attribute and
             servertype_attribute.related_via_attribute
         ):
-            if edit_mode:
-                continue
-            else:
-                is_related_attribute = True
+            is_related_attribute = True
 
         fields_set.add(key)
         fields.append({


### PR DESCRIPTION
Fix related attributes are editable but submitted values are ignored.
Related attributes should only be displayed but not be editable.