### PR TITLE
Fix ProgrammingError: syntax error near "AND"

### DIFF
--- a/serveradmin/serverdb/sql_generator.py
+++ b/serveradmin/serverdb/sql_generator.py
@@ -223,7 +223,7 @@ def _condition_sql(attribute, template, related_vias):
     if attribute.type == 'domain':
         return _exists_sql(Server, 'sub', (
             "sub.servertype_id = '{0}'".format(attribute.target_servertype_id),
-            "server.hostname ~ ('\\A[^\.]+\.' || regexp_replace(",
+            "server.hostname ~ ('\\A[^\.]+\.' || regexp_replace("
             "sub.hostname, '(\*|\-|\.)', '\\\1', 'g') || '\\Z')",
             template.format('sub.server_id'),
         ))


### PR DESCRIPTION
Remove extra comma in SQL query string concatention to avoid joining it together as 2 "where" conditions with AND.