### PR TITLE
inspect: added links to related objects

### DIFF
--- a/serveradmin/servershell/templates/servershell/inspect.html
+++ b/serveradmin/servershell/templates/servershell/inspect.html
@@ -41,11 +41,11 @@
                         {% if field.multi and field.value != None %}
                             <ul>
                                 {% for val in field.value %}
-                                    <li>{{ val|value_to_str:field.type }}</li>
+                                    <li>{{ val|value_to_str:field.type|link_to_object:field.type }}</li>
                                 {% endfor %}
                             </ul>
-                        {% else %}
-                            {% if field.value != None %}{{ field.value|value_to_str:field.type }}{% endif %}
+                        {% elif field.value != None %}
+                            {{ field.value|value_to_str:field.type|link_to_object:field.type }}
                         {% endif %}
                     </td>
                     <td>{{ field.type }}</td>

--- a/serveradmin/servershell/templatetags/servershell.py
+++ b/serveradmin/servershell/templatetags/servershell.py
@@ -1,6 +1,8 @@
 from datetime import timezone
 
 from django import template
+from django.utils.safestring import mark_safe
+from django.utils.html import escape
 
 register = template.Library()
 
@@ -25,6 +27,24 @@ def field_to_str(field: dict) -> str:
         return '\n'.join(values)
 
     return value_to_str(field['value'], field['type'])
+
+
+@register.filter
+def link_to_object(value, field_type) -> str:
+    """If the given object is a reference to another object,
+    create a link to the inspection page
+
+
+    :param value:
+    :param field_type:
+    :return:
+    """
+    if field_type not in ['relation', 'reverse']:
+        return value
+
+    hostname = escape(value)
+
+    return mark_safe(f'<a href="/servershell/inspect?hostname={hostname}">{hostname}</a>')
 
 
 @register.filter


### PR DESCRIPTION
Works for single/multi relation/reverse objects.
-> makes it much easier to jump from the inspection page to related objects with just one click.

![Screenshot 2022-11-04 at 15 21 09](https://user-images.githubusercontent.com/1894271/199997948-df81c4f8-47ed-43dc-8a5f-e5a682dbd81e.png)

![Screenshot 2022-11-04 at 15 14 48](https://user-images.githubusercontent.com/1894271/199996558-ba88ebf9-9d16-4179-92ed-d4c40f817805.png)


