### PR TITLE
Add command to sum numeric attributes

### DIFF
--- a/serveradmin/servershell/static/js/servershell/autocomplete/command.js
+++ b/serveradmin/servershell/static/js/servershell/autocomplete/command.js
@@ -115,7 +115,7 @@ $(document).ready(function() {
                         }
                     });
                 }
-                if (command === 'attr' || command === 'export' || command === 'diff') {
+                if (command === 'attr' || command === 'export' || command === 'diff' || command === 'sum') {
                     values = values.split(',').map(v => v.trim());
                     let search_string = values.pop();
                     let attribute_ids = get_attribute_ids(search_string, values);

--- a/serveradmin/servershell/static/js/servershell/command.js
+++ b/serveradmin/servershell/static/js/servershell/command.js
@@ -684,6 +684,38 @@ servershell.commands = {
 
         window.open(url, '_blank');
     },
+    sum: function(attribute_id) {
+        if (!validate_selected()) {
+            return;
+        }
+        let attribute = servershell.get_attribute(attribute_id);
+        if (!attribute) {
+            servershell.alert(`Attribute ${attribute_id} does not exist`, 'warning');
+            return;
+        }
+        if (attribute.type !== 'number') {
+            servershell.alert(`Attribute ${attribute_id} is not a number`, 'warning');
+            return;
+        }
+        // Add not yet visible attributes ...
+        let to_add = [attribute_id].filter(a => servershell.shown_attributes.find(b => b === a) === undefined);
+        servershell.shown_attributes.splice(servershell.shown_attributes.length, 0, ...to_add);
+
+        $(document).one('servershell_search_finished', function() {
+            let sum = 0;
+            let selected = servershell.get_selected();
+            let servers = servershell.servers.filter(s => selected.includes(s.object_id));
+            servers.forEach(function(object) {
+                if (object.hasOwnProperty(attribute_id)) {
+                    sum += isNaN(object[attribute_id]) ? 0 : object[attribute_id];
+                }
+            });
+
+            $('#sum_text').text(sum);
+            $('#sum_attribute_text').text(attribute_id);
+            $('#modal_sum').modal('show');
+        });
+    }
 };
 
 /**

--- a/serveradmin/servershell/templates/servershell/index.html
+++ b/serveradmin/servershell/templates/servershell/index.html
@@ -179,6 +179,7 @@
     <!-- The modals for editing and other commands -->
     {# We can probably make one general modal template out of these #}
     {% include "servershell/modals/export.html" %}
+    {% include "servershell/modals/sum.html" %}
 {% endblock %}
 
 {% block additional_scripts %}

--- a/serveradmin/servershell/templates/servershell/modals/help_command.html
+++ b/serveradmin/servershell/templates/servershell/modals/help_command.html
@@ -263,6 +263,16 @@
                                 Show differences of attributes for selected objects.
                             </td>
                         </tr>
+                        <tr id="cmd-sum">
+                            <td>sum</td>
+                            <td>attr_name</td>
+                            <td>
+                                Show sum of given attribute for selected objects.
+                                Example:
+                                "<code>sum num_cpu</code>"
+                            </td>
+                        </tr>
+
                     </tbody>
                 </table>
             </div>

--- a/serveradmin/servershell/templates/servershell/modals/sum.html
+++ b/serveradmin/servershell/templates/servershell/modals/sum.html
@@ -1,0 +1,20 @@
+<div class="modal fade" id="modal_sum" tabindex="-1">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Sum of <code id="sum_attribute_text"></code></h5>
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body" style="font-size: 125%">
+                Total sum:
+                <code id="sum_text"></code>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close
+                </button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Hi,

this PR adds the functionality to `sum` numeric attributes of the selected servers.
I've needed this so often that I wanted to e.g. sum all the memory of the servers that I searched for or wanted to know the number of cores. What I currently need to do is either using the `export` command or completely resort to the `adminapi` and commandline. For the latter, this is especially bad because not everyone - especially developers - has this setup. But even if, I'd wish I wouldn't need to switch tools for just simple aggregrations.

The new command looks as follows:
```
sum [attribute_id]
sum num_cpu
```
<img width="493" alt="image" src="https://user-images.githubusercontent.com/6304496/201286535-f578a8d1-ed10-4635-87a1-142d584b3c9f.png">

<img width="993" alt="image" src="https://user-images.githubusercontent.com/6304496/201286590-4e881748-ae88-476e-8512-3bc0cae7aa98.png">

I can obviously count to 4 in the screenshot, but I hope you get the idea. Especially with non-uniform values and a bigger list of servers this is just tedious sometimes.

The autocompletion hooks onto the one for `attr` and alike, which supports multiple values I think. This is not perfect. Maybe you can polish this with your domain knowledge of the tool. But it works for now and doesn't break the tool. You will get an alert that you did something wrong, which felt sufficient for my use cases.

Let me know what you think.
Cheers,
Christoph