### PR TITLE
Ignore requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ __pycache__/
 # Virtual Environment
 /venv/
 /.env
+
+# Pipenv
+/requirements.txt


### PR DESCRIPTION
One should use pipenv. We ignore ones requirements.txt that might be created to satisfy ones local IDE's import check.