### PR TITLE
Display clone column on Admin attribute listing

### DIFF
--- a/serveradmin/serverdb/admin.py
+++ b/serveradmin/serverdb/admin.py
@@ -76,9 +76,10 @@ class AttributeAdmin(admin.ModelAdmin):
         'get_hovertext',
         'multi',
         'readonly',
+        'clone',
     ]
     search_fields = ['attribute_id', ]
-    list_filter = ['type', 'group', 'multi', 'readonly', ]
+    list_filter = ['type', 'group', 'multi', 'readonly', 'clone', ]
 
     def get_readonly_fields(self, request, obj=None):
         fields = super().get_readonly_fields(request, obj)


### PR DESCRIPTION
Here is a quick change to display if an attribute is cloned when listing the attributes in the admin page:

![image](https://user-images.githubusercontent.com/1342887/209479158-15030a72-2cfe-4aa5-90fa-b16e0c6f2a80.png)
