### PR TITLE
Do not submit search without term in Servershell 

### DIFF
--- a/serveradmin/servershell/static/js/servershell/search.js
+++ b/serveradmin/servershell/static/js/servershell/search.js
@@ -68,6 +68,13 @@ servershell.submit_search = function() {
         return servershell.alert('Pending request, cancel it or wait for it to finish!', 'danger');
     }
 
+    // Do not submit search on load.
+    let params = new URLSearchParams(window.location.search);
+    if (servershell.term === null && !params.has('term')) {
+        servershell.term = '';
+        return;
+    }
+
     let url = $('#search_form').get(0).action;
     console.debug(`Submitting query to URL "${url}" with data:`);
     spinner.enable('search');

--- a/serveradmin/servershell/templates/servershell/index.html
+++ b/serveradmin/servershell/templates/servershell/index.html
@@ -200,7 +200,7 @@
 
         // Initialize servershell object properties with initial values
         // from backend. This allows us setting defaults from backend.
-        servershell.term = "{{ term|escapejs }}";
+        servershell.term = {% if term %}"{{ term|escapejs }}"{% else %}null{% endif %};
         servershell._term = "{{ term|escapejs }}";
         servershell.command = "";
         servershell.understood = "";

--- a/serveradmin/servershell/views.py
+++ b/serveradmin/servershell/views.py
@@ -97,7 +97,7 @@ def index(request):
             shown_attributes = get_default_shown_attributes()
 
     return TemplateResponse(request, 'servershell/index.html', {
-        'term': request.GET.get('term', request.session.get('term', '')),
+        'term': request.GET.get('term', request.session.get('term')),
         'shown_attributes': shown_attributes,
         'deep_link': bool(strtobool(request.GET.get('deep_link', 'false'))),
         'attributes': attributes_json,


### PR DESCRIPTION
Avoid long loading times for all objects when users open the page by not submitting the search when the term is empty.

One can still submit ".*" if one really wants to see all objects.