### PR TITLE
Suggest command as first match at auto completion

### DIFF
--- a/serveradmin/servershell/static/js/servershell/autocomplete/command.js
+++ b/serveradmin/servershell/static/js/servershell/autocomplete/command.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
                 Object.keys(commands).sort().forEach(function(name) {
                     if (
                         command === '' ||
-                        (name !== command && name.startsWith(command))
+                        name.startsWith(command)
                     ) {
                         let desc = $(`#cmd-${name} td:nth-of-type(3)`).text();
                         desc = desc === undefined ? '' : desc;
@@ -71,16 +71,14 @@ $(document).ready(function() {
                     }
                 });
 
-                if (choices.length === 0) {
-                    servershell.attributes.map(item => item.attribute_id).sort().forEach(function(attribute) {
-                        if (attribute !== command && attribute.startsWith(command)) {
-                            choices.push({
-                                'label': `${attribute}`,
-                                'value': `${attribute} `,
-                            });
-                        }
-                    });
-                }
+                servershell.attributes.map(item => item.attribute_id).sort().forEach(function(attribute) {
+                    if (attribute !== command && attribute.startsWith(command)) {
+                        choices.push({
+                            'label': `${attribute}: Display attribute`,
+                            'value': `${attribute} `,
+                        });
+                    }
+                });
             }
             else {
                 // Auto complete for certain commands and its values


### PR DESCRIPTION
When typing the full name of a command make the command itself the first suggestion in the auto completion.

Additionally always suggest attributes but below command suggestions.