### PR TITLE
Display attributes with no history

### DIFF
--- a/serveradmin/serverdb/static/css/history.css
+++ b/serveradmin/serverdb/static/css/history.css
@@ -5,3 +5,11 @@ table {
 table th {
     min-width: 125px;
 }
+
+.attributes {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 200px;
+    grid-template-rows: repeat(5, 1fr);
+    margin-top: 15px;
+}

--- a/serveradmin/serverdb/templates/serverdb/history.html
+++ b/serveradmin/serverdb/templates/serverdb/history.html
@@ -9,14 +9,24 @@
 {% block content %}
 <form id="changes-form" method="get" action="{% url 'serverdb_history' %}">
     <div class="row">
-        <div class="col-md-3"></div>
-        <div class="col-md-6">
+        <div class="col-md-12">
             <h3>History for {{ name }}</h3>
         </div>
     </div>
     <div class="row">
-        <div class="col-md-3"></div>
-        <div class="col-md-6 controls">
+        <div class="col-md-12 controls">
+            {% if no_history_attributes %}
+            <div class="form-group row">
+                Attributes which have history disabled and won't show up here:
+            </div>
+            <div>
+                <ul class="attributes">
+                    {% for attribute in no_history_attributes %}
+                        <li>{{ attribute.attribute_id }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
             <div class="form-group row input-controls">
                 <label for="attribute_filter" class="col-sm-1 col-form-label">Attribute:</label>
                 <div class="col-md-4">

--- a/serveradmin/serverdb/views.py
+++ b/serveradmin/serverdb/views.py
@@ -19,7 +19,7 @@ from serveradmin.serverdb.models import (
     ChangeCommit,
     Server,
     ServertypeAttribute,
-    Change,
+    Change, Attribute,
 )
 from serveradmin.serverdb.query_committer import CommitError, commit_query
 
@@ -116,12 +116,19 @@ def history(request):
     pager = Paginator(obj_history, 25)
     page_obj = pager.get_page(page)
 
+    no_history_attributes = ServertypeAttribute.objects.filter(
+        servertype_id=server.servertype_id
+    ).select_related('attribute').filter(
+        attribute__history=False
+    ).only('attribute_id')
+
     return TemplateResponse(request, 'serverdb/history.html', {
         'changes': page_obj,
         'commit_id': commit_id,
         'object_id': object_id,
         'name': server.hostname,
         'attribute_filter': attribute_filter,
+        'no_history_attributes': no_history_attributes,
     })
 
 


### PR DESCRIPTION
Show attributes where history is disabled to make the user aware that those won't show up.