### PR TITLE
Improve performance to fetch hostname for changes

### DIFF
--- a/serveradmin/serverdb/models.py
+++ b/serveradmin/serverdb/models.py
@@ -4,14 +4,6 @@ Copyright (c) 2021 InnoGames GmbH
 """
 
 import re
-import json
-import netfields
-
-from typing import Union
-
-from django.core.serializers.json import DjangoJSONEncoder
-from django.db.models import Q
-from netaddr import EUI
 from distutils.util import strtobool
 from ipaddress import (
     IPv4Address,
@@ -23,17 +15,21 @@ from ipaddress import (
     IPv4Network,
     IPv6Network,
 )
+from typing import Union
 
+import netfields
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
+from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import RegexValidator
 from django.db import models
+from django.db.models import Q
 from django.utils.timezone import now
 from django.utils.translation import gettext as _
+from netaddr import EUI
 
 from adminapi.datatype import STR_BASED_DATATYPES
 from serveradmin.apps.models import Application
-
 
 ATTRIBUTE_TYPES = {
     'string': str,
@@ -800,26 +796,3 @@ class Change(models.Model):
 
     class Meta:
         app_label = 'serverdb'
-
-    def hostname(self):
-        """Get last hostname for object of Change
-
-        Get the current hostname if the object still exists or the last known
-        one when deleted.
-
-        :return:
-        """
-
-        if self.change_type == Change.Type.DELETE:
-            return self.change_json['hostname']
-        else:
-            try:
-                return Server.objects.filter(
-                    pk=self.object_id).only('hostname').get().hostname
-            except Server.DoesNotExist:
-                # We seem to have re-used the same object_id in the past in
-                # some exceptions - in such as case just pick the latest.
-                return Change.objects.filter(
-                    object_id=self.object_id,
-                    change_type=Change.Type.DELETE
-                ).order_by('-id').first().change_json['hostname']

--- a/serveradmin/serverdb/templates/serverdb/changes.html
+++ b/serveradmin/serverdb/templates/serverdb/changes.html
@@ -85,7 +85,7 @@
                             <ul>
                             {% for change in commit.change_set.get_queryset %}
                                 {% if change.change_type == 'create' %}
-                                    <li><a href="{% url 'serverdb_history' %}?commit_id={{ commit.id }}&object_id={{ change.object_id }}">View history of {{ change.hostname }}</a></li>
+                                    <li><a href="{% url 'serverdb_history' %}?commit_id={{ commit.id }}&object_id={{ change.object_id }}">History for {{ change.hostname }}</a></li>
                                 {% endif %}
                             {% endfor %}
                             </ul>
@@ -94,7 +94,7 @@
                             <ul>
                             {% for change in commit.change_set.get_queryset %}
                                 {% if change.change_type == 'change' %}
-                                    <li><a href="{% url 'serverdb_history' %}?commit_id={{ commit.id }}&object_id={{ change.object_id }}">View history of {{ change.hostname }}</a></li>
+                                    <li><a href="{% url 'serverdb_history' %}?commit_id={{ commit.id }}&object_id={{ change.object_id }}">History for {{ change.hostname }}</a></li>
                                 {% endif %}
                             {% endfor %}
                             </ul>
@@ -103,7 +103,7 @@
                             <ul>
                             {% for change in commit.change_set.get_queryset %}
                                 {% if change.change_type == 'delete' %}
-                                    <li><a href="{% url 'serverdb_restore' change.id %}">Restore object {{ change.hostname }}</a></li>
+                                    <li><a href="{% url 'serverdb_restore' change.id %}">Recreate {{ change.hostname }}</a></li>
                                 {% endif %}
                             {% endfor %}
                             </ul>

--- a/serveradmin/serverdb/templates/serverdb/changes.html
+++ b/serveradmin/serverdb/templates/serverdb/changes.html
@@ -81,7 +81,6 @@
                         <td>{{ commit.change_on|timesince }}</td>
                         <td>{{ commit.app|default:"Servershell" }}</td>
                         <td>{{ commit.user }}</td>
-                        {# TODO: Find a way to avoid a SQL query for each Change to get the hostname by object_id #}
                         <td>
                             <ul>
                             {% for change in commit.change_set.get_queryset %}


### PR DESCRIPTION
Speed up loading time of the changes page for commits, especially with changes 
to multiple hosts, by avoiding to make a query for each hostname but prefetch 
the hostname when querying the changes.