### PR TITLE
Improve graphite cache generation

### DIFF
--- a/serveradmin/graphite/management/commands/cache_graphite.py
+++ b/serveradmin/graphite/management/commands/cache_graphite.py
@@ -1,6 +1,6 @@
 """Serveradmin - Graphite Integration
 
-Copyright (c) 2022 InnoGames GmbH
+Copyright (c) 2023 InnoGames GmbH
 """
 
 import json
@@ -33,7 +33,7 @@ from serveradmin.serverdb.models import Server
 
 
 class Command(BaseCommand):
-    """Generate sprites from the overview graphics"""
+    """Generate sprites and update numeric values for collections."""
     help = __doc__
 
     def handle(self, *args, **kwargs):

--- a/serveradmin/graphite/management/commands/cache_graphite.py
+++ b/serveradmin/graphite/management/commands/cache_graphite.py
@@ -44,6 +44,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """The entry point of the command"""
 
+        start = time.time()
+
         sprite_params = settings.GRAPHITE_SPRITE_PARAMS
         sprite_dir = settings.MEDIA_ROOT + '/graph_sprite'
         if not isdir(sprite_dir):
@@ -77,6 +79,9 @@ class Command(BaseCommand):
                 self.stdout.write(f"[{now()}] Updated numerics for {server['hostname']}")
 
             self.stdout.write(f"[{now()}] Finished collection {collection}")
+
+        end = time.time()
+        self.stdout.write(self.style.SUCCESS(f"Total time: {end - start:.2f} seconds."))
 
     def generate_sprite(self, collection_dir, graph_table, server):
         """Generate sprites for the given server using the given collection"""

--- a/serveradmin/graphite/management/commands/cache_graphite.py
+++ b/serveradmin/graphite/management/commands/cache_graphite.py
@@ -19,7 +19,7 @@ from urllib.request import (
 
 from PIL import Image
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandParser
 from django.db import transaction
 
 from adminapi import filters
@@ -36,7 +36,10 @@ class Command(BaseCommand):
     """Generate sprites and update numeric values for collections."""
     help = __doc__
 
-    def handle(self, *args, **kwargs):
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--collections", nargs='*', type=str, help='Generate/update only these collections.')
+
+    def handle(self, *args, **options):
         """The entry point of the command"""
 
         start = time.time()
@@ -47,7 +50,11 @@ class Command(BaseCommand):
             mkdir(sprite_dir)
 
         # We will make sure to generate a single sprite for a single hostname.
-        for collection in Collection.objects.filter(overview=True):
+        collections = Collection.objects.filter(overview=True)
+        if options['collections']:
+            collections = collections.filter(name__in=options['collections'])
+
+        for collection in collections:
             collection_start = time.time()
 
             collection_dir = sprite_dir + '/' + collection.name


### PR DESCRIPTION
- Reduce runtime by requesting sprites and numerics concurrently from Graphite
- Allow to update only specific collections for specific hosts
- Add details to logging output, print current time and add colors
- Don't raise exception if host has been deleted while generating sprites and numerics