### PR TITLE
Allow Serveradmin apps to extend the Servershell (Javascript)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 4.14.0
+* Allow Serveradmin apps to extend the Servershell (Javascript) [PR!348](https://github.com/innogames/serveradmin/pull/348)
+
 ## 4.13.0
 * Extend inet attributes and improve ip address type validation [PR!346](https://github.com/innogames/serveradmin/pull/346)
 * Bump cryptography from 42.0.2 to 42.0.4 (#347) 

--- a/serveradmin/servershell/static/js/servershell/command.js
+++ b/serveradmin/servershell/static/js/servershell/command.js
@@ -172,6 +172,18 @@ function validate_selected(min=1, max=-1) {
     return true;
 }
 
+// Serveradmin Servershell plugins can provide help for custom commands by
+// extending the servershell.commands_help array like in the example below in
+// their static/js/$app.servershell.plugin.js
+servershell.commands_help = [
+    // Example:
+    // {
+    //     "command": "foo",
+    //     "arguments": "attr_name",
+    //     "description": "A foo that bars",
+    // }
+]
+
 servershell.commands = {
     pin: function() {
         let selected_ids = servershell.get_selected();
@@ -770,7 +782,23 @@ function execute_command() {
 }
 
 $(document).ready(function() {
-   $('#command_form').submit(function(event) {
+
+    // Gather description for custom commands from Servershell plugins and add
+    // them to the help modal.
+    servershell.commands_help.forEach(function(command_help) {
+        let row = document.createElement("tr");
+        row.id = `cmd-${command_help["command"]}`;
+
+        for (let index of ["command", "arguments", "description"]) {
+            let cell = document.createElement("td");
+            cell.innerText = command_help[index];
+            row.appendChild(cell);
+        }
+
+        $("#help_command").append(row);
+    });
+
+    $('#command_form').submit(function(event) {
         event.preventDefault();
 
         // Workaround:
@@ -786,5 +814,5 @@ $(document).ready(function() {
        if (execute_command()) {
            servershell.command = '';
        }
-   })
+    });
 });

--- a/serveradmin/servershell/templates/servershell/index.html
+++ b/serveradmin/servershell/templates/servershell/index.html
@@ -235,4 +235,8 @@
         servershell.sync_attrlist_visibility();
     });
 </script>
+{% for plugin in servershell_plugins %}
+    {# Load javascript files from serveradmin apps for easy extension  #}
+    <script src="{{ STATIC_URL }}{{ plugin }}"></script>
+{% endfor %}
 {% endblock %}

--- a/serveradmin/servershell/utils.py
+++ b/serveradmin/servershell/utils.py
@@ -1,0 +1,22 @@
+from django.apps import apps
+from django.contrib.staticfiles import finders
+
+
+def servershell_plugins():
+    """Find $app.servershell.plugin.js files from Serveradmin apps
+
+    Scans all apps beginning with serveradmin_ for files that follow the pattern
+    $app.servershell.plugin.js and return them. This allows apps to add
+    commands to the Servershell.
+
+    @return:
+    """
+    js_files = list()
+    app_names = [app.name for app in apps.get_app_configs() if app.name.startswith("serveradmin_")]
+    for app_name in app_names:
+        path = f"js/{app_name}.servershell.plugin.js"
+        js_file = finders.find(path)
+        if js_file:
+            js_files.append(path)
+
+    return js_files

--- a/serveradmin/servershell/utils.py
+++ b/serveradmin/servershell/utils.py
@@ -6,8 +6,8 @@ def servershell_plugins():
     """Find $app.servershell.plugin.js files from Serveradmin apps
 
     Scans all apps beginning with serveradmin_ for files that follow the pattern
-    $app.servershell.plugin.js and return them. This allows apps to add
-    commands to the Servershell.
+    $app.servershell.plugin.js and return them. This allows Serveradmin apps to
+    extend the Servershell for example with custom commands.
 
     @return:
     """

--- a/serveradmin/servershell/views.py
+++ b/serveradmin/servershell/views.py
@@ -49,6 +49,7 @@ from serveradmin.servershell.helper.autocomplete import (
     attribute_startswith
 )
 from serveradmin.servershell.merged_query_iterator import MergedQuery
+from serveradmin.servershell.utils import servershell_plugins
 
 MAX_DISTINGUISHED_VALUES = 50
 NUM_SERVERS_DEFAULT = 25
@@ -106,6 +107,7 @@ def index(request):
         'order_by': 'hostname',
         'filters': sorted([(f.__name__, f.__doc__) for f in filter_classes]),
         'search_settings': search_settings,
+        'servershell_plugins': servershell_plugins(),
     })
 
 


### PR DESCRIPTION
Allow Serveradmin apps to add custom JavaScript to allow extending the Servershell to add for example custom commands.