### PR TITLE
Fix hijacking of object possible

### DIFF
--- a/serveradmin/serverdb/query_committer.py
+++ b/serveradmin/serverdb/query_committer.py
@@ -376,7 +376,7 @@ def _access_control(
                 raise PermissionDenied(msg)
 
 
-def _acl_violations(changed_objects, obj, acl):
+def _acl_violations(touched_objects, pending_changes, acl):
     """Check if ACL allows all the changes to obj
 
     An ACL can fail to validate in two ways.  Every ACL has a filter describing
@@ -389,13 +389,13 @@ def _acl_violations(changed_objects, obj, acl):
 
     For more context read the _access_control() doc string.
 
-    Returns a list of human readable ACL violations on failure.
+    Returns a list of human-readable ACL violations on failure.
     Returns None on success.
     """
 
     violations = []
 
-    # Check wether the object matches all the attribute filters of the ACL
+    # Check whether the object matches all the attribute filters of the ACL
     for attribute_id, attribute_filter in acl.get_filters().items():
         # TODO: This relies on the object to have all attributes that are
         #  present in the attribute_filter which currently works because
@@ -403,7 +403,7 @@ def _acl_violations(changed_objects, obj, acl):
         #  This method would be better of not relying on the caller
         #  making sure passing down all relevant attributes which isn't
         #  even documented.
-        if not attribute_filter.matches(obj.get(attribute_id)):
+        if not attribute_filter.matches(pending_changes.get(attribute_id)):
             violations.append(
                 'Object is not covered by ACL "{}", Attribute "{}" '
                 'does not match the filter "{}".'.format(
@@ -417,22 +417,22 @@ def _acl_violations(changed_objects, obj, acl):
 
     # For existing objects we only check attributes which were changed
     # For new objects we only check attributes different to their default
-    if obj['object_id'] in changed_objects:
-        old_object = changed_objects[obj['object_id']]
+    if pending_changes['object_id'] in touched_objects:
+        old_object = touched_objects[pending_changes['object_id']]
     else:
-        old_object = get_default_attribute_values(obj['servertype'])
+        old_object = get_default_attribute_values(pending_changes['servertype'])
 
     # Gather attribute ids this ACL allows changing
     attribute_ids = acl.get_permissible_attribute_ids()
 
-    # Check wether all changed attributes are on this ACLs attribute whitelist
-    for attribute_id, attribute_value in obj.items():
+    # Check whether all changed attributes are on this ACLs attribute whitelist
+    for attribute_id, attribute_value in pending_changes.items():
         if (
             attribute_id not in attribute_ids and
             attribute_value != old_object[attribute_id]
         ):
             is_related_via: bool = ServertypeAttribute.objects.filter(
-                servertype_id=obj['servertype'],
+                servertype_id=pending_changes['servertype'],
                 attribute_id=attribute_id,
                 related_via_attribute__isnull=False
             ).exists()

--- a/serveradmin/serverdb/query_committer.py
+++ b/serveradmin/serverdb/query_committer.py
@@ -403,7 +403,15 @@ def _acl_violations(touched_objects, pending_changes, acl):
         #  This method would be better of not relying on the caller
         #  making sure passing down all relevant attributes which isn't
         #  even documented.
-        if not attribute_filter.matches(pending_changes.get(attribute_id)):
+        if pending_changes['object_id'] in touched_objects:
+            # If the object already exists ensure the ACL matches the status
+            # quo and not the wanted changes.
+            to_compare = touched_objects.get(pending_changes['object_id'])
+        else:
+            # Otherwise check if the ACL allows the "to be" object.
+            to_compare = pending_changes
+
+        if not attribute_filter.matches(to_compare.get(attribute_id)):
             violations.append(
                 'Object is not covered by ACL "{}", Attribute "{}" '
                 'does not match the filter "{}".'.format(

--- a/serveradmin/serverdb/tests/test_acls.py
+++ b/serveradmin/serverdb/tests/test_acls.py
@@ -18,22 +18,22 @@ class ACLTestCase(TransactionTestCase):
 
     """
 
-    fixtures = ["auth_user.json", "test_dataset.json"]
+    fixtures = ['auth_user.json', 'test_dataset.json']
 
     def test_deny_if_not_authenticated(self):
         with self.assertRaises(PermissionDenied) as error:
             # Trying to commit without being authenticated must not be possible.
             query_committer._access_control(None, None, {}, {}, {}, {})
-        self.assertEqual("Missing authentication!", str(error.exception))
+        self.assertEqual('Missing authentication!', str(error.exception))
 
     def test_permit_if_superuser_app(self):
         user = User.objects.first()
         app = Application.objects.create(
-            name="superuser test",
-            app_id="superuser test",
-            auth_token="secret",
+            name='superuser test',
+            app_id='superuser test',
+            auth_token='secret',
             owner=user,
-            location="test",
+            location='test',
         )
 
         self.assertIsNone(query_committer._access_control(None, app, {}, {}, {}, {}))
@@ -47,22 +47,22 @@ class ACLTestCase(TransactionTestCase):
     def test_deny_if_app_acl_does_not_cover_object(self):
         user = User.objects.first()
         app = Application.objects.create(
-            name="superuser test",
-            app_id="superuser test",
-            auth_token="secret",
+            name='superuser test',
+            app_id='superuser test',
+            auth_token='secret',
             owner=user,
-            location="test",
+            location='test',
         )
-        acl = AccessControlGroup.objects.create(name="app test", query="servertype=vm")
+        acl = AccessControlGroup.objects.create(name='app test', query='servertype=vm')
         acl.applications.add(app)
         acl.save()
 
-        unchanged_object = Query({"object_id": 1}, ["os", "hostname"]).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_object = Query({'object_id': 1}, ['os', 'hostname']).get()
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         with self.assertRaises(PermissionDenied) as error:
             query_committer._access_control(
@@ -79,16 +79,16 @@ class ACLTestCase(TransactionTestCase):
         user = User.objects.first()
         user.is_superuser = False
 
-        acl = AccessControlGroup.objects.create(name="app test", query="servertype=vm")
+        acl = AccessControlGroup.objects.create(name='app test', query='servertype=vm')
         acl.members.add(user)
         acl.save()
 
-        unchanged_object = Query({"object_id": 1}, ["os", "hostname"]).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_object = Query({'object_id': 1}, ['os', 'hostname']).get()
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         with self.assertRaises(PermissionDenied) as error:
             query_committer._access_control(
@@ -104,26 +104,26 @@ class ACLTestCase(TransactionTestCase):
     def test_permit_if_app_acl_covers_object(self):
         user = User.objects.first()
         app = Application.objects.create(
-            name="superuser test",
-            app_id="superuser test",
-            auth_token="secret",
+            name='superuser test',
+            app_id='superuser test',
+            auth_token='secret',
             owner=user,
-            location="test",
+            location='test',
         )
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=False
+            name='app test', query='servertype=test0', is_whitelist=False
         )
         acl.applications.add(app)
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         self.assertIsNone(
             query_committer._access_control(
@@ -135,19 +135,19 @@ class ACLTestCase(TransactionTestCase):
         user = User.objects.first()
         user.is_superuser = False
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=False
+            name='app test', query='servertype=test0', is_whitelist=False
         )
         acl.members.add(user)
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         self.assertIsNone(
             query_committer._access_control(
@@ -158,26 +158,26 @@ class ACLTestCase(TransactionTestCase):
     def test_deny_if_app_acl_whitelist_does_not_list_attribute(self):
         user = User.objects.first()
         app = Application.objects.create(
-            name="superuser test",
-            app_id="superuser test",
-            auth_token="secret",
+            name='superuser test',
+            app_id='superuser test',
+            auth_token='secret',
             owner=user,
-            location="test",
+            location='test',
         )
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=True
+            name='app test', query='servertype=test0', is_whitelist=True
         )
         acl.applications.add(app)
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         with self.assertRaises(PermissionDenied) as error:
             query_committer._access_control(
@@ -195,19 +195,19 @@ class ACLTestCase(TransactionTestCase):
         user.is_superuser = False
 
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=True
+            name='app test', query='servertype=test0', is_whitelist=True
         )
         acl.members.add(user)
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         with self.assertRaises(PermissionDenied) as error:
             query_committer._access_control(
@@ -223,27 +223,27 @@ class ACLTestCase(TransactionTestCase):
     def test_permit_if_app_acl_whitelist_lists_attribute(self):
         user = User.objects.first()
         app = Application.objects.create(
-            name="superuser test",
-            app_id="superuser test",
-            auth_token="secret",
+            name='superuser test',
+            app_id='superuser test',
+            auth_token='secret',
             owner=user,
-            location="test",
+            location='test',
         )
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=True
+            name='app test', query='servertype=test0', is_whitelist=True
         )
         acl.applications.add(app)
-        acl.attributes.add(Attribute.objects.get(attribute_id="os"))
+        acl.attributes.add(Attribute.objects.get(attribute_id='os'))
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         self.assertIsNone(
             query_committer._access_control(
@@ -255,20 +255,20 @@ class ACLTestCase(TransactionTestCase):
         user = User.objects.first()
         user.is_superuser = False
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=True
+            name='app test', query='servertype=test0', is_whitelist=True
         )
         acl.members.add(user)
-        acl.attributes.add(Attribute.objects.get(attribute_id="os"))
+        acl.attributes.add(Attribute.objects.get(attribute_id='os'))
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         self.assertIsNone(
             query_committer._access_control(
@@ -279,27 +279,27 @@ class ACLTestCase(TransactionTestCase):
     def test_deny_if_app_acl_blacklist_lists_attribute(self):
         user = User.objects.first()
         app = Application.objects.create(
-            name="superuser test",
-            app_id="superuser test",
-            auth_token="secret",
+            name='superuser test',
+            app_id='superuser test',
+            auth_token='secret',
             owner=user,
-            location="test",
+            location='test',
         )
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=False
+            name='app test', query='servertype=test0', is_whitelist=False
         )
         acl.applications.add(app)
-        acl.attributes.add(Attribute.objects.get(attribute_id="os"))
+        acl.attributes.add(Attribute.objects.get(attribute_id='os'))
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         with self.assertRaises(PermissionDenied) as error:
             query_committer._access_control(
@@ -316,20 +316,20 @@ class ACLTestCase(TransactionTestCase):
         user = User.objects.first()
         user.is_superuser = False
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=False
+            name='app test', query='servertype=test0', is_whitelist=False
         )
         acl.members.add(user)
-        acl.attributes.add(Attribute.objects.get(attribute_id="os"))
+        acl.attributes.add(Attribute.objects.get(attribute_id='os'))
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         with self.assertRaises(PermissionDenied) as error:
             query_committer._access_control(
@@ -345,26 +345,26 @@ class ACLTestCase(TransactionTestCase):
     def test_permit_if_app_acl_blacklist_misses_attribute(self):
         user = User.objects.first()
         app = Application.objects.create(
-            name="superuser test",
-            app_id="superuser test",
-            auth_token="secret",
+            name='superuser test',
+            app_id='superuser test',
+            auth_token='secret',
             owner=user,
-            location="test",
+            location='test',
         )
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=False
+            name='app test', query='servertype=test0', is_whitelist=False
         )
         acl.applications.add(app)
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         self.assertIsNone(
             query_committer._access_control(
@@ -376,19 +376,19 @@ class ACLTestCase(TransactionTestCase):
         user = User.objects.first()
         user.is_superuser = False
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=False
+            name='app test', query='servertype=test0', is_whitelist=False
         )
         acl.members.add(user)
         acl.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
-        changed_object = Query({"object_id": 1}, ["os", "hostname", "servertype"]).get()
-        changed_object["os"] = "bookworm"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object = Query({'object_id': 1}, ['os', 'hostname', 'servertype']).get()
+        changed_object['os'] = 'bookworm'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         self.assertIsNone(
             query_committer._access_control(
@@ -402,38 +402,38 @@ class ACLTestCase(TransactionTestCase):
 
         user = User.objects.first()
         app = Application.objects.create(
-            name="superuser test",
-            app_id="superuser test",
-            auth_token="secret",
+            name='superuser test',
+            app_id='superuser test',
+            auth_token='secret',
             owner=user,
-            location="test",
+            location='test',
         )
 
         acl_1 = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=True
+            name='app test', query='servertype=test0', is_whitelist=True
         )
         acl_1.applications.add(app)
-        acl_1.attributes.add(Attribute.objects.get(attribute_id="os"))
+        acl_1.attributes.add(Attribute.objects.get(attribute_id='os'))
         acl_1.save()
 
         acl_2 = AccessControlGroup.objects.create(
-            name="app test 2", query="servertype=test0", is_whitelist=True
+            name='app test 2', query='servertype=test0', is_whitelist=True
         )
         acl_2.applications.add(app)
-        acl_2.attributes.add(Attribute.objects.get(attribute_id="database"))
+        acl_2.attributes.add(Attribute.objects.get(attribute_id='database'))
         acl_2.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "database", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'database', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
         changed_object = Query(
-            {"object_id": 1}, ["os", "database", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'database', 'hostname', 'servertype']
         ).get()
-        changed_object["os"] = "bookworm"
-        changed_object["database"] = "bingo"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object['os'] = 'bookworm'
+        changed_object['database'] = 'bingo'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         with self.assertRaises(PermissionDenied) as error:
             query_committer._access_control(
@@ -444,7 +444,7 @@ class ACLTestCase(TransactionTestCase):
             '"superuser test": Change is not covered by ACL "app test", '
             'Attribute "database" was modified despite not beeing whitelisted.'
             'Change is not covered by ACL "app test 2", Attribute "os" was '
-            "modified despite not beeing whitelisted.",
+            'modified despite not beeing whitelisted.',
             str(error.exception),
         )
 
@@ -456,30 +456,30 @@ class ACLTestCase(TransactionTestCase):
         user.is_superuser = False
 
         acl_1 = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=True
+            name='app test', query='servertype=test0', is_whitelist=True
         )
         acl_1.members.add(user)
-        acl_1.attributes.add(Attribute.objects.get(attribute_id="os"))
+        acl_1.attributes.add(Attribute.objects.get(attribute_id='os'))
         acl_1.save()
 
         acl_2 = AccessControlGroup.objects.create(
-            name="app test 2", query="servertype=test0", is_whitelist=True
+            name='app test 2', query='servertype=test0', is_whitelist=True
         )
         acl_1.members.add(user)
-        acl_2.attributes.add(Attribute.objects.get(attribute_id="database"))
+        acl_2.attributes.add(Attribute.objects.get(attribute_id='database'))
         acl_2.save()
 
         unchanged_object = Query(
-            {"object_id": 1}, ["os", "database", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'database', 'hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
         changed_object = Query(
-            {"object_id": 1}, ["os", "database", "hostname", "servertype"]
+            {'object_id': 1}, ['os', 'database', 'hostname', 'servertype']
         ).get()
-        changed_object["os"] = "bookworm"
-        changed_object["database"] = "bingo"
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object['os'] = 'bookworm'
+        changed_object['database'] = 'bingo'
+        changed_objects = {changed_object['object_id']: changed_object}
 
         with self.assertRaises(PermissionDenied) as error:
             query_committer._access_control(
@@ -489,7 +489,7 @@ class ACLTestCase(TransactionTestCase):
             'Insufficient access rights to object "test0" for user '
             '"hannah.acker": Change is not covered by ACL "app test", '
             'Attribute "database" was modified despite not beeing '
-            "whitelisted.",
+            'whitelisted.',
             str(error.exception),
         )
 
@@ -502,21 +502,21 @@ class ACLTestCase(TransactionTestCase):
         user.is_superuser = False
 
         acl = AccessControlGroup.objects.create(
-            name="app test", query="servertype=test0", is_whitelist=False
+            name='app test', query='servertype=test0', is_whitelist=False
         )
         acl.members.add(user)
         acl.save()
 
         unchanged_object = Query(
-            {"hostname": "test2", "servertype": "test2"}, ["hostname", "servertype"]
+            {'hostname': 'test2', 'servertype': 'test2'}, ['hostname', 'servertype']
         ).get()
-        unchanged_objects = {unchanged_object["object_id"]: unchanged_object}
+        unchanged_objects = {unchanged_object['object_id']: unchanged_object}
 
         changed_object = Query(
-            {"hostname": "test2", "servertype": "test2"}, ["hostname", "servertype"]
+            {'hostname': 'test2', 'servertype': 'test2'}, ['hostname', 'servertype']
         ).get()
-        changed_object["servertype"] = "test0"  # Attacker attempts to hijack object
-        changed_objects = {changed_object["object_id"]: changed_object}
+        changed_object['servertype'] = 'test0'  # Attacker attempts to hijack object
+        changed_objects = {changed_object['object_id']: changed_object}
 
         with self.assertRaises(PermissionDenied) as error:
             query_committer._access_control(


### PR DESCRIPTION
Compare changes to existing objects to the status quo and not the
pending changes to not allow an attacker to get in control of an object
by changing the values matching an ACL the attacker has control to.