### PR TITLE
Fix pagination does not work on history page

### DIFF
--- a/serveradmin/serverdb/templates/serverdb/history.html
+++ b/serveradmin/serverdb/templates/serverdb/history.html
@@ -152,7 +152,7 @@
     </div>
     <div class="row">
         <div class="col-md-12">
-            {% include "pagination.html" with page=changes form=True %}
+            {% include "pagination.html" with page=changes form=True form_id="changes-form" %}
         </div>
     </div>
 </form>


### PR DESCRIPTION
Set form_id parameter to ensure pagination is finding the correct form to submit.