### PR TITLE
Render HTML contained in messages

### DIFF
--- a/serveradmin/common/templates/base.html
+++ b/serveradmin/common/templates/base.html
@@ -58,7 +58,7 @@
     {% if messages %}
         {% for message in messages %}
             <div class="alert {{ message.level_tag|bootstrap_alert }} alert-dismissible fade show" role="alert">
-                <strong>{{ message }}</strong>
+                <strong>{{ message|safe }}</strong>
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>


### PR DESCRIPTION
For some messages it is useful to render the HTML such as for example if you have multiple messages and want to display them as list.