### PR TITLE
[fix] servershell: Do not wrap table headers

### DIFF
--- a/serveradmin/servershell/static/css/servershell.css
+++ b/serveradmin/servershell/static/css/servershell.css
@@ -16,6 +16,7 @@ table tr:nth-child(odd) .disabled {
 
 #result_table thead th {
     padding-right: 1ch;
+    white-space: nowrap;
 }
 
 .results-info:last-of-type {


### PR DESCRIPTION
Seems to be missed on testing, this does not allow 2nd line on table headers when zoomed.