### PR TITLE
servershell: Trim prefix/suffix whitespace on queries

### DIFF
--- a/serveradmin/servershell/static/js/servershell/search.js
+++ b/serveradmin/servershell/static/js/servershell/search.js
@@ -8,7 +8,7 @@
  */
 async function _search(url, search_term, pinned = [], focus_command_input = false) {
     let request_data = {
-        term: search_term, // Avoid error on trailing spaces
+        term: search_term.trim(), // Ensure trimmed value is sent to backend
         shown_attributes: servershell.shown_attributes,
         deep_link: servershell.deep_link,
         offset: servershell.offset,
@@ -130,6 +130,11 @@ $(document).ready(function() {
     // Submit form with Ajax and prevent normal submission
     $('#search_form').submit(function(event) {
         event.preventDefault();
+        // Trim the search term and update the input field
+        let searchInput = $('#term');
+        let trimmedValue = searchInput.val().trim();
+        searchInput.val(trimmedValue);
+        servershell.term = trimmedValue;
         servershell.submit_search(true);
     });
 

--- a/serveradmin/servershell/static/js/servershell/search.js
+++ b/serveradmin/servershell/static/js/servershell/search.js
@@ -8,7 +8,7 @@
  */
 async function _search(url, search_term, pinned = [], focus_command_input = false) {
     let request_data = {
-        term: search_term.trim(), // Ensure trimmed value is sent to backend
+        term: search_term,
         shown_attributes: servershell.shown_attributes,
         deep_link: servershell.deep_link,
         offset: servershell.offset,
@@ -131,10 +131,7 @@ $(document).ready(function() {
     $('#search_form').submit(function(event) {
         event.preventDefault();
         // Trim the search term and update the input field
-        let searchInput = $('#term');
-        let trimmedValue = searchInput.val().trim();
-        searchInput.val(trimmedValue);
-        servershell.term = trimmedValue;
+        servershell.term = servershell.term.trim();
         servershell.submit_search(true);
     });
 


### PR DESCRIPTION
This is disturbing, especially on copy paste. Did a simple fix which should be enough but please ping if I am missing a case. .trim() should only care about prefixed and suffixed ones.