### PR TITLE
Validate attribute type for type relation

### DIFF
--- a/serveradmin/serverdb/admin.py
+++ b/serveradmin/serverdb/admin.py
@@ -8,7 +8,7 @@ from django.utils.html import format_html
 
 from serveradmin.serverdb.forms import (
     ServertypeAttributeAdminForm,
-    ServertypeAdminForm,
+    ServertypeAdminForm, AttributeAdminForm,
 )
 from serveradmin.serverdb.models import (
     Servertype,
@@ -68,6 +68,7 @@ class ServerAdmin(admin.ModelAdmin):
 
 
 class AttributeAdmin(admin.ModelAdmin):
+    form = AttributeAdminForm
     list_display = [
         'attribute_id',
         'type',

--- a/serveradmin/serverdb/forms.py
+++ b/serveradmin/serverdb/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
 
-from serveradmin.serverdb.models import ServertypeAttribute
+from serveradmin.serverdb.models import ServertypeAttribute, Attribute
 
 
 class ServertypeAdminForm(forms.ModelForm):
@@ -32,4 +32,15 @@ class ServertypeAttributeAdminForm(forms.ModelForm):
                 'Adding an attribute of type inet or supernet when '
                 'ip_addr_type is null is not possible!')
 
+        super().clean()
+
+
+class AttributeAdminForm(forms.ModelForm):
+    class Meta:
+        model = Attribute
+        fields = '__all__'
+
+    def clean(self):
+        if self.cleaned_data['type'] != 'relation' and self.cleaned_data['target_servertype'] is not None:
+            raise ValidationError('Attribute type must be relation when target servertype is selected!')
         super().clean()


### PR DESCRIPTION
Ensure the attribute type is validation when specifying a target servertype instread of crashing with an exception or HTTP 500.

Before
<img width="1396" height="492" alt="Screenshot From 2025-09-04 13-30-26" src="https://github.com/user-attachments/assets/30fd66db-c412-41fe-8f07-150fdf84953b" />

After
<img width="1396" height="492" alt="Screenshot From 2025-09-04 13-30-37" src="https://github.com/user-attachments/assets/b025a30a-b9b4-49b8-a442-d160f0058a4f" />
