### PR TITLE
graphs bug: all rows are multiplied by the number of selected objects

### DIFF
--- a/serveradmin/graphite/views.py
+++ b/serveradmin/graphite/views.py
@@ -68,8 +68,8 @@ def graph_table(request):
             assert isinstance(value, MultiAttr)
             if not any(collection.name == v for v in value):
                 break  # The server hasn't got this attribute value.
-            else:
-                collections.append(collection)
+        else:
+            collections.append(collection)
 
     # Prepare the graph descriptions
     descriptions = []


### PR DESCRIPTION
like here `/graphite/graph_table?object_id=123&object_id=123&object_id=125`
-> all rows appear 3 times per host