### PR TITLE
servershell: Add regexp() support to multidel command

### DIFF
--- a/serveradmin/servershell/templates/servershell/modals/help_command.html
+++ b/serveradmin/servershell/templates/servershell/modals/help_command.html
@@ -210,8 +210,13 @@
                         </tr>
                         <tr id="cmd-multidel">
                             <td>multidel</td>
-                            <td>attr_name=value1[,value2[,...]</td>
-                            <td>Delete values from a multi attribute</td>
+                            <td>attr_name=value1[,value2[,...]]</td>
+                            <td>
+                                Delete values from a multi attribute
+                                <p>
+                                    Supports Regexp(): "multidel tags=Regexp(.*test.*)"
+                                </p>
+                            </td>
                         </tr>
                         <tr id="cmd-delete">
                             <td>delete</td>


### PR DESCRIPTION
Uses the similar case-insensitive regexp() approach we have as filter, so following examples would work:

- `multidel myattr=regexp(somevalue)`
- `multidel myattr=Regexp(somevalue)`
- `multidel myattr=regexp(somevalue),nonregexvalue`
- `multidel myattr=regexp(.*anothervalue)` 