### PR TITLE
Add commit id in commit_query signal

### DIFF
--- a/serveradmin/serverdb/query_committer.py
+++ b/serveradmin/serverdb/query_committer.py
@@ -132,7 +132,9 @@ def commit_query(created=[], changed=[], deleted=[], app=None, user=None):
         commit_id = _log_changes(user, app, changed, created_objects, deleted_objects)
 
     post_commit.send_robust(
-        commit_query, created=created, changed=changed, deleted=deleted
+        commit_query,
+        commit_id=commit_id,
+        created=created, changed=changed, deleted=deleted,
     )
 
     return DatasetCommit(

--- a/serveradmin/settings.py
+++ b/serveradmin/settings.py
@@ -17,7 +17,7 @@ SECRET_KEY = env('SECRET_KEY', default=None)
 
 DEBUG = env('DEBUG', default=False)
 
-ALLOWED_HOSTS = env('ALLOWED_HOSTS', default=[])
+ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=[])
 
 # Default model used for the implicit generate primary key when no attribute
 # of a model as primary_key = True.


### PR DESCRIPTION
This change adds the commit id returned when committing changes to the parameters of the post_commit signal so that listeners can consume it and work with it.

It additionally ensure the settings.ALLOWED_HOSTS is always a list.