### PR TITLE
Fix deprecation warnings for trixie (python 3.13)

### DIFF
--- a/serveradmin/serverdb/migrations/0007_hostname_regex_hyphens.py
+++ b/serveradmin/serverdb/migrations/0007_hostname_regex_hyphens.py
@@ -26,13 +26,13 @@ class Migration(migrations.Migration):
                 "ALTER TABLE server "
                 "DROP CONSTRAINT server_hostname_check, "
                 "ADD CONSTRAINT server_hostname_check "
-                "CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9]+(\.|-+))*[a-z0-9]+\Z'::text);"
+                r"CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9]+(\.|-+))*[a-z0-9]+\Z'::text);"
             ),
             reverse_sql=(
                 "ALTER TABLE server "
                 "DROP CONSTRAINT server_hostname_check, "
                 "ADD CONSTRAINT server_hostname_check "
-                "CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9]+[\.\-])*[a-z0-9]+\Z'::text);"
+                r"CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9]+[\.\-])*[a-z0-9]+\Z'::text);"
             )
         ),
     ]

--- a/serveradmin/serverdb/migrations/0018_alter_server_hostname.py
+++ b/serveradmin/serverdb/migrations/0018_alter_server_hostname.py
@@ -21,13 +21,13 @@ class Migration(migrations.Migration):
                 "ALTER TABLE server "
                 "DROP CONSTRAINT server_hostname_check, "
                 "ADD CONSTRAINT server_hostname_check "
-                "CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9_]+(\.|-+))*[a-z0-9]+\Z'::text);"
+                r"CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9_]+(\.|-+))*[a-z0-9]+\Z'::text);"
             ),
             reverse_sql=(
                 "ALTER TABLE server "
                 "DROP CONSTRAINT server_hostname_check, "
                 "ADD CONSTRAINT server_hostname_check "
-                "CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9]+(\.|-+))*[a-z0-9]+\Z'::text);"
+                r"CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9]+(\.|-+))*[a-z0-9]+\Z'::text);"
             )
         ),
     ]

--- a/serveradmin/serverdb/sql_generator.py
+++ b/serveradmin/serverdb/sql_generator.py
@@ -235,8 +235,8 @@ def _condition_sql(attribute, template, related_vias):
     if attribute.type == 'domain':
         return _exists_sql(Server, 'sub', (
             _target_servertype_sql('sub', attribute),
-            "server.hostname ~ ('\\A[^\.]+\.' || regexp_replace("
-            "sub.hostname, '(\*|\-|\.)', '\\\1', 'g') || '\\Z')",
+            r"server.hostname ~ ('\A[^\.]+\.' || regexp_replace("
+            r"sub.hostname, '(\*|\-|\.)', '\\\1', 'g') || '\Z')",
             template.format('sub.server_id'),
         ))
     if attribute.type == 'reverse':

--- a/serveradmin/serverdb/sql_generator.py
+++ b/serveradmin/serverdb/sql_generator.py
@@ -243,8 +243,8 @@ def _condition_sql(attribute, template, related_vias):
     if attribute.type == 'domain':
         return _exists_sql(Server, 'sub', (
             _target_servertype_sql('sub', attribute),
-            "server.hostname ~ ('\\A[^\.]+\.' || regexp_replace("
-            "sub.hostname, '(\*|\-|\.)', '\\\1', 'g') || '\\Z')",
+            r"server.hostname ~ ('\A[^\.]+\.' || regexp_replace("
+            r"sub.hostname, '(\*|\-|\.)', '\\\1', 'g') || '\Z')",
             template.format('sub.server_id'),
         ))
     if attribute.type == 'reverse':

--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,10 @@ if __name__ == '__main__':
                 'templates/servershell/modals/*',
             ],
         },
-        entry_points={
-            'console_scripts': [
-                'serveradmin=serveradmin.__main__:main',
-                'adminapi=adminapi.__main__:main',
-            ],
-        },
+        scripts=[
+            'bin/adminapi',
+            'bin/serveradmin',
+        ],
         install_requires=[
             'paramiko>=2.7,<4',
             'netaddr>=0.8.0,<1.4.0',


### PR DESCRIPTION
```
/usr/lib/python3/dist-packages/serveradmin/serverdb/migrations/0007_hostname_regex_hyphens.py:29: SyntaxWarning: invalid escape sequence '\A'
  "CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9]+(\.|-+))*[a-z0-9]+\Z'::text);"
/usr/lib/python3/dist-packages/serveradmin/serverdb/migrations/0007_hostname_regex_hyphens.py:35: SyntaxWarning: invalid escape sequence '\A'
  "CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9]+[\.\-])*[a-z0-9]+\Z'::text);"
/usr/lib/python3/dist-packages/serveradmin/serverdb/migrations/0018_alter_server_hostname.py:24: SyntaxWarning: invalid escape sequence '\A'
  "CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9_]+(\.|-+))*[a-z0-9]+\Z'::text);"
/usr/lib/python3/dist-packages/serveradmin/serverdb/migrations/0018_alter_server_hostname.py:30: SyntaxWarning: invalid escape sequence '\A'
  "CHECK (hostname::text ~ '\A(\*\.)?([a-z0-9]+(\.|-+))*[a-z0-9]+\Z'::text);"
/usr/lib/python3/dist-packages/serveradmin/serverdb/sql_generator.py:226: SyntaxWarning: invalid escape sequence '\.'
  "server.hostname ~ ('\\A[^\.]+\.' || regexp_replace("
/usr/lib/python3/dist-packages/serveradmin/serverdb/sql_generator.py:227: SyntaxWarning: invalid escape sequence '\*'
  "sub.hostname, '(\*|\-|\.)', '\\\1', 'g') || '\\Z')",
```