### PR TITLE
Fix "newer data available" in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           # This will use Python's standard unit test discovery feature.
           pipenv run python -m unittest discover adminapi -v
-          pipenv run python -Wall -m serveradmin test --noinput --parallel=1
+          pipenv run python -Wall -m serveradmin test --noinput --parallel=10
           # Build sphinx docs, error on warning
           cd docs
           SPHINXBUILD='pipenv run sphinx-build' SPHINXOPTS='-W' make html

--- a/serveradmin/serverdb/query_committer.py
+++ b/serveradmin/serverdb/query_committer.py
@@ -645,7 +645,7 @@ def _validate_commit(changes, servers):
                     newer.append((object_id, attr, server[attr]))
             elif action == 'update' or action == 'delete':
                 try:
-                    if json_encode_extra(server[attr]) != str(change['old']):
+                    if json_encode_extra(server[attr]) != json_encode_extra(change['old']):
                         newer.append((object_id, attr, server[attr]))
                 except KeyError:
                     newer.append((object_id, attr, None))


### PR DESCRIPTION
_validate_commit compared the current value via json_encode_extra()
against the old value via str(). For datetime attributes these never
match, since str() keeps microseconds and the "+00:00" tz form while
json_encode_extra() drops both.
